### PR TITLE
fix: add favicon to metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Pastor App",
   description: "Ministry Platform Pastor Application",
+  icons: {
+    icon: "/assets/icons/favicon.ico",
+  },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
- Added favicon reference to root layout metadata
- Favicon located at /public/assets/icons/favicon.ico
- Next.js requires favicon to be declared in metadata.icons for proper display

Amp-Thread-ID: https://ampcode.com/threads/T-d16f919e-3593-41ab-ad06-d2f52c90fa2d