### PR TITLE
Refactor: move SessionProvider to contexts folder

### DIFF
--- a/src/components/auth-wrapper.tsx
+++ b/src/components/auth-wrapper.tsx
@@ -1,6 +1,6 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { SessionProvider } from "@/components/session-provider";
+import { SessionProvider } from "@/contexts";
 
 export async function AuthWrapper({ children }: { children: React.ReactNode }) {
   const session = await auth();

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,13 +6,12 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
 import { UserCircleIcon } from "@heroicons/react/24/solid";
 import { Sidebar } from "@/components/sidebar";
 import { UserMenu } from "@/components/user-menu/user-menu";
-import { useSession } from "@/components/session-provider";
-import { useUser } from "@/contexts/user-context";
+import { useAppSession, useUser } from "@/contexts";
 
 export function Header() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { userProfile, isLoading } = useUser();
-  const session = useSession();
+  const session = useAppSession();
 
   console.log("Header rendered session: ", session);
 

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export { UserProvider, useUser } from "./user-context";
+export { SessionProvider, useAppSession } from "./session-context";

--- a/src/contexts/session-context.tsx
+++ b/src/contexts/session-context.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { createContext, useContext } from 'react';
-import type { Session } from 'next-auth';
+import { createContext, useContext } from "react";
+import type { Session } from "next-auth";
 
 const SessionContext = createContext<Session | null>(null);
 
@@ -12,7 +12,6 @@ export function SessionProvider({
   children: React.ReactNode;
   session: Session;
 }) {
-  console.log('SessionProvider session: ', session);
   return (
     <SessionContext.Provider value={session}>
       {children}
@@ -20,10 +19,10 @@ export function SessionProvider({
   );
 }
 
-export function useSession() {
+export function useAppSession() {
   const session = useContext(SessionContext);
-  if (session === undefined) {
-    throw new Error('useSession must be used within a SessionProvider');
+  if (session === null) {
+    throw new Error("useAppSession must be used within a SessionProvider");
   }
   return session;
 }


### PR DESCRIPTION
## Summary
- Move `session-provider.tsx` from `components/` to `contexts/session-context.tsx`
- Rename `useSession` hook to `useAppSession` to avoid conflict with next-auth's `useSession`
- Fix null check bug (was checking `undefined` but context default is `null`)
- Remove `console.log` debug statement
- Update barrel exports and imports across affected files

## Test plan
- [ ] Verify app builds successfully (`npm run build`)
- [ ] Test authenticated pages load correctly
- [ ] Verify `useAppSession` hook returns session data

🤖 Generated with [Claude Code](https://claude.com/claude-code)