### PR TITLE
Add schema documentation generation to type generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,3 +146,4 @@ await mp.createTableRecords('Contact_Log', records, {
 For detailed context on specific areas, see:
 
 - **[Components Reference](.claude/references/components.md)** - Detailed inventory of all components, their purposes, server actions, and compliance status
+- **[Ministry Platform Schema](.claude/references/ministryplatform.schema.md)** - Auto-generated summary of Ministry Platform database tables, primary keys, and foreign key relationships


### PR DESCRIPTION
## Summary

- Add auto-generation of `ministryplatform.schema.md` reference document when running `npm run mp:generate:models`
- Generated schema doc includes table names (A-Z sorted), access levels, primary keys, and foreign key relationships
- Update CLAUDE.md to reference the new schema documentation

## Test plan

- [ ] Run `npm run mp:generate:models` and verify `.claude/references/ministryplatform.schema.md` is created
- [ ] Confirm tables are sorted alphabetically in the generated doc
- [ ] Confirm primary keys and foreign key relationships are listed correctly
- [ ] Verify CLAUDE.md has the new reference link
- [ ] Run `npm run build` to ensure no TypeScript errors

---

🤖 Generated with [Claude Code](https://claude.ai/code)