### PR TITLE
Add npm run setup command for project initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A modern Next.js application integrated with Ministry Platform authentication an
 - [Architecture](#architecture)
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
+  - [Quick Setup with Claude Code](#quick-setup-with-claude-code)
+  - [Manual Setup](#manual-setup)
   - [OAuth Setup](#oauth-setup)
 - [Project Structure](#project-structure)
 - [Ministry Platform Integration](#ministry-platform-integration)
@@ -15,6 +17,7 @@ A modern Next.js application integrated with Ministry Platform authentication an
 - [Services](#services)
 - [Testing](#testing)
 - [Development](#development)
+- [Claude Code Commands](#claude-code-commands)
 - [Documentation](#documentation)
 - [Code Style & Conventions](#code-style--conventions)
 
@@ -62,20 +65,58 @@ NextAuth v5 (beta) with custom Ministry Platform OAuth provider (`src/auth.ts`)
 
 ## Getting Started
 
-### 1. Clone the Repository
+### Quick Setup with Claude Code
+
+If you have [Claude Code](https://claude.ai/code) installed, the setup process is automated:
+
+```bash
+git clone https://github.com/MinistryPlatform-Community/MPNext.git
+cd MPNext
+npm install
+npm run setup
+```
+
+The interactive setup command will:
+1. Verify Node.js version (v18+ required)
+2. Check git status
+3. Create `.env.local` from `.env.example` (if needed)
+4. Prompt for missing environment variables
+5. Auto-generate `NEXTAUTH_SECRET` (optional)
+6. Install and update dependencies
+7. Generate Ministry Platform types
+8. Run a production build to verify configuration
+
+**Additional setup options:**
+```bash
+npm run setup:check     # Validation only (no changes)
+npm run setup -- --clean       # Clean install (delete node_modules first)
+npm run setup -- --skip-install # Skip npm install/update
+npm run setup -- --verbose     # Extra output
+npm run setup -- --help        # Show all options
+```
+
+Once setup completes, run `npm run dev` and visit http://localhost:3000.
+
+---
+
+### Manual Setup
+
+If you prefer manual setup or don't have Claude Code:
+
+#### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/MinistryPlatform-Community/MPNext.git
 cd MPNext
 ```
 
-### 2. Install Dependencies
+#### 2. Install Dependencies
 
 ```bash
 npm install
 ```
 
-### 3. Environment Configuration
+#### 3. Environment Configuration
 
 Copy the example environment file and configure it with your Ministry Platform credentials:
 
@@ -629,6 +670,83 @@ npm start
 ```
 
 > **Note**: The build process includes TypeScript type checking. Ensure all generated types are up to date by running `npm run mp:generate:models` before building.
+
+## Claude Code Commands
+
+This project includes custom [Claude Code](https://claude.ai/code) commands (skills) to streamline development workflows. These commands are invoked using the `/command` syntax in Claude Code.
+
+### Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/audit-deps` | Security and update audit for dependencies |
+| `/branch-commit [args]` | Create branch and commit changes, optionally linked to GitHub issue |
+| `/pr [args]` | Create a pull request with validation |
+
+### `/audit-deps` - Dependency Audit
+
+Performs a comprehensive security and update analysis of project dependencies.
+
+**What it does:**
+- Runs `npm audit` for vulnerability detection
+- Searches for recent CVEs affecting major dependencies
+- Categorizes updates as safe (patch/minor) or major (breaking changes)
+- Generates a prioritized action plan
+
+**Usage:**
+```
+/audit-deps
+```
+
+### `/branch-commit` - Branch and Commit
+
+Creates a new branch from the current branch, stages all changes, and commits with detailed notes. Can auto-generate branch name and commit message from a GitHub issue.
+
+**Usage:**
+```
+/branch-commit                           # Prompts for branch name and commit message
+/branch-commit #123                      # Auto-generates from GitHub issue #123
+/branch-commit feature/my-change: Add new feature  # Manual branch and commit message
+/branch-commit #123 fix/custom-name: Custom message  # Issue reference with custom names
+```
+
+**Branch naming convention:**
+- `fix/issue-<id>-<slug>` - For bug fixes (issues with "bug" label)
+- `feature/issue-<id>-<slug>` - For features/enhancements
+
+### `/pr` - Pull Request
+
+Creates a pull request after validating all prerequisites are met.
+
+**Validations performed:**
+- Not on main/master/dev branch
+- No uncommitted changes
+- Branch pushed to origin
+- No existing open PR for branch
+
+**Usage:**
+```
+/pr                    # Create PR to main branch
+/pr --base dev         # Create PR to dev branch
+/pr --draft            # Create as draft PR
+/pr #123               # Link to specific GitHub issue
+```
+
+**PR format includes:**
+- Summary section with bullet points
+- Test plan checklist
+- Issue links (auto-detected from commits)
+- Claude Code attribution
+
+### Command Files
+
+Command definitions are stored in `.claude/commands/`:
+```
+.claude/commands/
+├── audit-deps.md      # Dependency audit command
+├── branch-commit.md   # Branch and commit command
+└── pr.md              # Pull request command
+```
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@inquirer/prompts": "^7.0.0",
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.9.1",
@@ -50,6 +51,7 @@
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.21",
+        "chalk": "^5.3.0",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
         "jsdom": "^27.4.0",
@@ -1801,6 +1803,356 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5295,21 +5647,24 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -5321,6 +5676,16 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/client-only": {
@@ -6332,6 +6697,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -6929,6 +7311,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -7160,6 +7559,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -8093,6 +8502,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9136,6 +9555,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9368,6 +9794,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9411,6 +9850,28 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -9523,6 +9984,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -10240,6 +10714,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -10504,6 +10979,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -10559,6 +11049,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "mp:generate": "tsx src/lib/providers/ministry-platform/scripts/generate-types.ts",
-    "mp:generate:models": "tsx src/lib/providers/ministry-platform/scripts/generate-types.ts -o src/lib/providers/ministry-platform/models --zod --clean"
+    "mp:generate:models": "tsx src/lib/providers/ministry-platform/scripts/generate-types.ts -o src/lib/providers/ministry-platform/models --zod --clean",
+    "setup": "tsx scripts/setup.ts",
+    "setup:check": "tsx scripts/setup.ts --check"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -45,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@inquirer/prompts": "^7.0.0",
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.9.1",
@@ -56,6 +59,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.21",
+    "chalk": "^5.3.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "jsdom": "^27.4.0",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,0 +1,946 @@
+#!/usr/bin/env tsx
+
+/**
+ * MPNext Setup CLI
+ *
+ * Interactive setup command that guides developers through the complete
+ * project setup process, validating configuration and running all
+ * necessary initialization steps.
+ *
+ * Usage:
+ *   npm run setup         # Interactive mode
+ *   npm run setup:check   # Validation-only mode
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync, spawn } from 'node:child_process';
+import chalk from 'chalk';
+import { confirm, input, password } from '@inquirer/prompts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SetupOptions {
+  check: boolean;
+  clean: boolean;
+  skipInstall: boolean;
+  verbose: boolean;
+}
+
+interface StepResult {
+  success: boolean;
+  warning?: boolean;
+  message: string;
+  details?: string;
+}
+
+interface EnvVar {
+  name: string;
+  required: boolean;
+  sensitive: boolean;
+  description: string;
+  autoGenerate?: boolean;
+  defaultValue?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const ENV_LOCAL_PATH = path.join(PROJECT_ROOT, '.env.local');
+const ENV_EXAMPLE_PATH = path.join(PROJECT_ROOT, '.env.example');
+const NODE_MODULES_PATH = path.join(PROJECT_ROOT, 'node_modules');
+const MODELS_PATH = path.join(
+  PROJECT_ROOT,
+  'src',
+  'lib',
+  'providers',
+  'ministry-platform',
+  'models'
+);
+const NEXT_BUILD_PATH = path.join(PROJECT_ROOT, '.next');
+
+const REQUIRED_NODE_VERSION = 18;
+
+const ENV_VARS: EnvVar[] = [
+  // Required variables
+  {
+    name: 'OIDC_CLIENT_ID',
+    required: true,
+    sensitive: false,
+    description: 'OAuth client ID for user authentication',
+  },
+  {
+    name: 'OIDC_CLIENT_SECRET',
+    required: true,
+    sensitive: true,
+    description: 'OAuth client secret for user authentication',
+  },
+  {
+    name: 'MINISTRY_PLATFORM_CLIENT_ID',
+    required: true,
+    sensitive: false,
+    description: 'Ministry Platform API client ID',
+  },
+  {
+    name: 'MINISTRY_PLATFORM_CLIENT_SECRET',
+    required: true,
+    sensitive: true,
+    description: 'Ministry Platform API client secret',
+  },
+  {
+    name: 'MINISTRY_PLATFORM_BASE_URL',
+    required: true,
+    sensitive: false,
+    description: 'Ministry Platform API base URL',
+  },
+  {
+    name: 'NEXTAUTH_SECRET',
+    required: true,
+    sensitive: true,
+    description: 'NextAuth encryption secret',
+    autoGenerate: true,
+  },
+  {
+    name: 'NEXTAUTH_URL',
+    required: true,
+    sensitive: false,
+    description: 'Application URL',
+    defaultValue: 'http://localhost:3000',
+  },
+  // Optional variables
+  {
+    name: 'OIDC_PROVIDER_NAME',
+    required: false,
+    sensitive: false,
+    description: 'OAuth provider display name',
+  },
+  {
+    name: 'OIDC_SCOPE',
+    required: false,
+    sensitive: false,
+    description: 'OAuth scopes',
+  },
+  {
+    name: 'OIDC_WELL_KNOWN_URL',
+    required: false,
+    sensitive: false,
+    description: 'OIDC well-known configuration URL',
+  },
+  {
+    name: 'NEXT_PUBLIC_MINISTRY_PLATFORM_FILE_URL',
+    required: false,
+    sensitive: false,
+    description: 'Ministry Platform file URL',
+  },
+  {
+    name: 'NEXT_PUBLIC_APP_NAME',
+    required: false,
+    sensitive: false,
+    description: 'Application display name',
+  },
+  {
+    name: 'NEXTAUTH_DEBUG',
+    required: false,
+    sensitive: false,
+    description: 'Enable NextAuth debug logging',
+  },
+];
+
+// ============================================================================
+// Argument Parsing
+// ============================================================================
+
+function parseArguments(): SetupOptions {
+  const args = process.argv.slice(2);
+  const options: SetupOptions = {
+    check: false,
+    clean: false,
+    skipInstall: false,
+    verbose: false,
+  };
+
+  for (const arg of args) {
+    switch (arg) {
+      case '--check':
+        options.check = true;
+        break;
+      case '--clean':
+        options.clean = true;
+        break;
+      case '--skip-install':
+        options.skipInstall = true;
+        break;
+      case '--verbose':
+        options.verbose = true;
+        break;
+      case '-h':
+      case '--help':
+        showHelp();
+        process.exit(0);
+      default:
+        console.error(chalk.red(`Unknown option: ${arg}`));
+        showHelp();
+        process.exit(2);
+    }
+  }
+
+  return options;
+}
+
+function showHelp(): void {
+  console.log(`
+${chalk.bold('MPNext Setup')}
+
+Usage: npm run setup [options]
+
+Options:
+  --check         Validation-only mode (no modifications)
+  --clean         Delete node_modules before install
+  --skip-install  Skip npm install/update steps
+  --verbose       Extra output
+  -h, --help      Show this help message
+
+Examples:
+  npm run setup              # Interactive setup
+  npm run setup:check        # Check configuration only
+  npm run setup -- --clean   # Clean install
+`);
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+function parseEnvFile(filePath: string): Map<string, string> {
+  const env = new Map<string, string>();
+
+  if (!fs.existsSync(filePath)) {
+    return env;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const equalIndex = trimmed.indexOf('=');
+    if (equalIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, equalIndex).trim();
+    let value = trimmed.slice(equalIndex + 1).trim();
+
+    // Remove surrounding quotes if present
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    env.set(key, value);
+  }
+
+  return env;
+}
+
+function updateEnvFile(filePath: string, updates: Map<string, string>): void {
+  let content = '';
+
+  if (fs.existsSync(filePath)) {
+    content = fs.readFileSync(filePath, 'utf-8');
+  }
+
+  for (const [key, value] of updates) {
+    const regex = new RegExp(`^${key}=.*$`, 'm');
+    const newLine = `${key}=${value}`;
+
+    if (regex.test(content)) {
+      content = content.replace(regex, newLine);
+    } else {
+      // Add to end of file
+      if (content && !content.endsWith('\n')) {
+        content += '\n';
+      }
+      content += `${newLine}\n`;
+    }
+  }
+
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+function execCommand(
+  command: string,
+  options?: { verbose?: boolean; silent?: boolean }
+): { success: boolean; output: string; error?: string } {
+  try {
+    const output = execSync(command, {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf-8',
+      stdio: options?.silent ? 'pipe' : options?.verbose ? 'inherit' : 'pipe',
+    });
+    return { success: true, output: output?.toString() || '' };
+  } catch (error) {
+    const execError = error as { stdout?: Buffer; stderr?: Buffer; message: string };
+    return {
+      success: false,
+      output: execError.stdout?.toString() || '',
+      error: execError.stderr?.toString() || execError.message,
+    };
+  }
+}
+
+async function execCommandStreaming(
+  command: string,
+  args: string[],
+  verbose: boolean
+): Promise<{ success: boolean; output: string }> {
+  return new Promise((resolve) => {
+    const proc = spawn(command, args, {
+      cwd: PROJECT_ROOT,
+      shell: true,
+      stdio: verbose ? 'inherit' : 'pipe',
+    });
+
+    let output = '';
+
+    if (!verbose && proc.stdout) {
+      proc.stdout.on('data', (data) => {
+        output += data.toString();
+      });
+    }
+
+    if (!verbose && proc.stderr) {
+      proc.stderr.on('data', (data) => {
+        output += data.toString();
+      });
+    }
+
+    proc.on('close', (code) => {
+      resolve({ success: code === 0, output });
+    });
+
+    proc.on('error', (error) => {
+      resolve({ success: false, output: error.message });
+    });
+  });
+}
+
+function getNodeVersion(): number | null {
+  const match = process.version.match(/^v(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+function countFilesInDir(dir: string): number {
+  if (!fs.existsSync(dir)) {
+    return 0;
+  }
+
+  let count = 0;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isFile()) {
+      count++;
+    } else if (entry.isDirectory()) {
+      count += countFilesInDir(path.join(dir, entry.name));
+    }
+  }
+
+  return count;
+}
+
+function printStepHeader(stepNum: number, totalSteps: number, name: string): void {
+  console.log(chalk.cyan(`\n[${stepNum}/${totalSteps}] ${name}...`));
+}
+
+function printResult(result: StepResult): void {
+  if (result.success && !result.warning) {
+    console.log(chalk.green(`  ✓ ${result.message}`));
+  } else if (result.warning) {
+    console.log(chalk.yellow(`  ⚠ ${result.message}`));
+  } else {
+    console.log(chalk.red(`  ✗ ${result.message}`));
+  }
+
+  if (result.details) {
+    console.log(chalk.gray(`    ${result.details}`));
+  }
+}
+
+async function generateNextAuthSecret(): Promise<string> {
+  // Generate a random secret using Node.js crypto
+  const { randomBytes } = await import('node:crypto');
+  return randomBytes(32).toString('base64');
+}
+
+// ============================================================================
+// Step Functions
+// ============================================================================
+
+function checkNodeVersion(): StepResult {
+  const version = getNodeVersion();
+
+  if (version === null) {
+    return {
+      success: false,
+      message: 'Could not determine Node.js version',
+    };
+  }
+
+  if (version < REQUIRED_NODE_VERSION) {
+    return {
+      success: false,
+      message: `Node.js v${version} is below minimum required v${REQUIRED_NODE_VERSION}`,
+      details: 'Please upgrade Node.js to v18 or later',
+    };
+  }
+
+  return {
+    success: true,
+    message: `Node.js ${process.version} (meets v${REQUIRED_NODE_VERSION}+ requirement)`,
+  };
+}
+
+function checkGitStatus(): StepResult {
+  const result = execCommand('git status --porcelain', { silent: true });
+
+  if (!result.success) {
+    return {
+      success: true,
+      warning: true,
+      message: 'Could not check git status (not a git repository?)',
+    };
+  }
+
+  if (result.output.trim()) {
+    return {
+      success: true,
+      warning: true,
+      message: 'Uncommitted changes detected (warning only)',
+      details: 'Consider committing or stashing changes before setup',
+    };
+  }
+
+  return {
+    success: true,
+    message: 'Git working directory is clean',
+  };
+}
+
+function checkEnvFileExists(): StepResult {
+  if (fs.existsSync(ENV_LOCAL_PATH)) {
+    return {
+      success: true,
+      message: '.env.local exists',
+    };
+  }
+
+  return {
+    success: false,
+    message: '.env.local not found',
+    details: fs.existsSync(ENV_EXAMPLE_PATH)
+      ? 'Can be created from .env.example'
+      : '.env.example also missing - manual creation required',
+  };
+}
+
+async function createEnvFile(): Promise<StepResult> {
+  if (!fs.existsSync(ENV_EXAMPLE_PATH)) {
+    return {
+      success: false,
+      message: 'Cannot create .env.local - .env.example not found',
+    };
+  }
+
+  const content = fs.readFileSync(ENV_EXAMPLE_PATH, 'utf-8');
+  fs.writeFileSync(ENV_LOCAL_PATH, content, 'utf-8');
+
+  return {
+    success: true,
+    message: 'Created .env.local from .env.example',
+  };
+}
+
+function validateEnvVars(): {
+  result: StepResult;
+  missing: EnvVar[];
+  empty: EnvVar[];
+} {
+  const env = parseEnvFile(ENV_LOCAL_PATH);
+  const missing: EnvVar[] = [];
+  const empty: EnvVar[] = [];
+
+  for (const varDef of ENV_VARS) {
+    if (!varDef.required) continue;
+
+    const value = env.get(varDef.name);
+
+    if (value === undefined) {
+      missing.push(varDef);
+    } else if (value === '') {
+      empty.push(varDef);
+    }
+  }
+
+  const issues = [...missing, ...empty];
+
+  if (issues.length === 0) {
+    return {
+      result: {
+        success: true,
+        message: 'All required environment variables are set',
+      },
+      missing,
+      empty,
+    };
+  }
+
+  const issueNames = issues.map((v) => v.name).join(', ');
+  return {
+    result: {
+      success: false,
+      message: `Missing or empty: ${issueNames}`,
+    },
+    missing,
+    empty,
+  };
+}
+
+function checkNodeModules(): StepResult {
+  if (fs.existsSync(NODE_MODULES_PATH)) {
+    return {
+      success: true,
+      message: 'node_modules exists',
+    };
+  }
+
+  return {
+    success: false,
+    message: 'node_modules not found',
+    details: 'Run npm install to install dependencies',
+  };
+}
+
+function checkMPTypes(): StepResult {
+  const count = countFilesInDir(MODELS_PATH);
+
+  if (count > 0) {
+    return {
+      success: true,
+      message: `${count} files in models/`,
+    };
+  }
+
+  return {
+    success: false,
+    message: 'No generated types found',
+    details: 'Run npm run mp:generate:models to generate types',
+  };
+}
+
+function checkBuildCache(): StepResult {
+  if (fs.existsSync(NEXT_BUILD_PATH)) {
+    return {
+      success: true,
+      message: '.next build cache exists',
+    };
+  }
+
+  return {
+    success: false,
+    message: 'No build cache found',
+    details: 'Run npm run build to create a production build',
+  };
+}
+
+// ============================================================================
+// Check Mode
+// ============================================================================
+
+function runCheckMode(): number {
+  console.log(chalk.bold.blue('\nMPNext Setup Check'));
+  console.log(chalk.blue('==================\n'));
+
+  const results: { name: string; result: StepResult }[] = [];
+
+  // Step 1: Node.js version
+  process.stdout.write(chalk.cyan('[1/7] Node.js version...        '));
+  const nodeResult = checkNodeVersion();
+  results.push({ name: 'Node.js', result: nodeResult });
+  if (nodeResult.success) {
+    console.log(chalk.green(`✓ ${process.version}`));
+  } else {
+    console.log(chalk.red(`✗ ${nodeResult.message}`));
+  }
+
+  // Step 2: Git status
+  process.stdout.write(chalk.cyan('[2/7] Git status...             '));
+  const gitResult = checkGitStatus();
+  results.push({ name: 'Git', result: gitResult });
+  if (gitResult.success && !gitResult.warning) {
+    console.log(chalk.green('✓ Clean'));
+  } else if (gitResult.warning) {
+    console.log(chalk.yellow('⚠ Uncommitted changes'));
+  } else {
+    console.log(chalk.red(`✗ ${gitResult.message}`));
+  }
+
+  // Step 3: Environment file
+  process.stdout.write(chalk.cyan('[3/7] Environment file...       '));
+  const envFileResult = checkEnvFileExists();
+  results.push({ name: 'Env file', result: envFileResult });
+  if (envFileResult.success) {
+    console.log(chalk.green('✓ .env.local exists'));
+  } else {
+    console.log(chalk.red('✗ Missing .env.local'));
+  }
+
+  // Step 4: Environment variables
+  process.stdout.write(chalk.cyan('[4/7] Environment variables...  '));
+  const { result: envVarsResult, missing, empty } = validateEnvVars();
+  results.push({ name: 'Env vars', result: envVarsResult });
+  if (envVarsResult.success) {
+    console.log(chalk.green('✓ All required vars set'));
+  } else {
+    const issues = [...missing, ...empty].map((v) => v.name);
+    console.log(chalk.red(`✗ Missing: ${issues.join(', ')}`));
+  }
+
+  // Step 5: Dependencies
+  process.stdout.write(chalk.cyan('[5/7] Dependencies...           '));
+  const depsResult = checkNodeModules();
+  results.push({ name: 'Dependencies', result: depsResult });
+  if (depsResult.success) {
+    console.log(chalk.green('✓ node_modules exists'));
+  } else {
+    console.log(chalk.red('✗ node_modules missing'));
+  }
+
+  // Step 6: MP types
+  process.stdout.write(chalk.cyan('[6/7] MP types...               '));
+  const typesResult = checkMPTypes();
+  results.push({ name: 'MP types', result: typesResult });
+  if (typesResult.success) {
+    const count = countFilesInDir(MODELS_PATH);
+    console.log(chalk.green(`✓ ${count} files in models/`));
+  } else {
+    console.log(chalk.red('✗ No generated types'));
+  }
+
+  // Step 7: Build cache
+  process.stdout.write(chalk.cyan('[7/7] Build cache...            '));
+  const buildResult = checkBuildCache();
+  results.push({ name: 'Build', result: buildResult });
+  if (buildResult.success) {
+    console.log(chalk.green('✓ .next exists'));
+  } else {
+    console.log(chalk.red('✗ No build cache'));
+  }
+
+  // Summary
+  const passed = results.filter((r) => r.result.success && !r.result.warning).length;
+  const warnings = results.filter((r) => r.result.warning).length;
+  const failed = results.filter((r) => !r.result.success).length;
+
+  console.log(chalk.bold(`\nSummary: ${passed} passed, ${warnings} warnings, ${failed} failed`));
+
+  return failed > 0 ? 1 : 0;
+}
+
+// ============================================================================
+// Interactive Mode
+// ============================================================================
+
+async function runInteractiveSetup(options: SetupOptions): Promise<number> {
+  console.log(chalk.bold.blue('\nMPNext Setup'));
+  console.log(chalk.blue('============'));
+
+  const totalSteps = 9;
+  let passedSteps = 0;
+  let warnings = 0;
+  let failedSteps = 0;
+
+  // Step 1: Node.js version check
+  printStepHeader(1, totalSteps, 'Checking Node.js version');
+  const nodeResult = checkNodeVersion();
+  printResult(nodeResult);
+
+  if (!nodeResult.success) {
+    console.log(chalk.red('\nSetup cannot continue without Node.js v18 or later.'));
+    return 1;
+  }
+  passedSteps++;
+
+  // Step 2: Git status check
+  printStepHeader(2, totalSteps, 'Checking git status');
+  const gitResult = checkGitStatus();
+  printResult(gitResult);
+
+  if (gitResult.warning) {
+    warnings++;
+  }
+  passedSteps++;
+
+  // Step 3: .env.local existence
+  printStepHeader(3, totalSteps, 'Checking environment file');
+  let envFileResult = checkEnvFileExists();
+
+  if (!envFileResult.success && fs.existsSync(ENV_EXAMPLE_PATH)) {
+    printResult(envFileResult);
+    const shouldCreate = await confirm({
+      message: 'Create .env.local from .env.example?',
+      default: true,
+    });
+
+    if (shouldCreate) {
+      envFileResult = await createEnvFile();
+      printResult(envFileResult);
+    } else {
+      console.log(chalk.red('\nSetup cannot continue without .env.local'));
+      return 1;
+    }
+  } else {
+    printResult(envFileResult);
+  }
+
+  if (!envFileResult.success) {
+    failedSteps++;
+  } else {
+    passedSteps++;
+  }
+
+  // Step 4: Environment variable validation
+  printStepHeader(4, totalSteps, 'Validating environment variables');
+  let { result: envVarsResult, missing, empty } = validateEnvVars();
+
+  if (!envVarsResult.success) {
+    printResult(envVarsResult);
+
+    const issues = [...missing, ...empty];
+    const updates = new Map<string, string>();
+
+    for (const varDef of issues) {
+      console.log(chalk.yellow(`\n  ${varDef.name}: ${varDef.description}`));
+
+      if (varDef.autoGenerate && varDef.name === 'NEXTAUTH_SECRET') {
+        const shouldGenerate = await confirm({
+          message: `Auto-generate ${varDef.name}?`,
+          default: true,
+        });
+
+        if (shouldGenerate) {
+          const secret = await generateNextAuthSecret();
+          updates.set(varDef.name, secret);
+          console.log(chalk.green(`  ✓ Generated ${varDef.name}`));
+        } else {
+          const value = await password({
+            message: `Enter ${varDef.name}:`,
+          });
+          if (value) {
+            updates.set(varDef.name, value);
+          }
+        }
+      } else if (varDef.sensitive) {
+        const value = await password({
+          message: `Enter ${varDef.name}:`,
+        });
+        if (value) {
+          updates.set(varDef.name, value);
+        }
+      } else {
+        const value = await input({
+          message: `Enter ${varDef.name}:`,
+          default: varDef.defaultValue,
+        });
+        if (value) {
+          updates.set(varDef.name, value);
+        }
+      }
+    }
+
+    if (updates.size > 0) {
+      updateEnvFile(ENV_LOCAL_PATH, updates);
+      console.log(chalk.green(`\n  ✓ Updated .env.local with ${updates.size} variable(s)`));
+    }
+
+    // Re-validate
+    const revalidation = validateEnvVars();
+    envVarsResult = revalidation.result;
+    if (envVarsResult.success) {
+      passedSteps++;
+    } else {
+      printResult(envVarsResult);
+      failedSteps++;
+    }
+  } else {
+    printResult(envVarsResult);
+    passedSteps++;
+  }
+
+  // Step 5: npm install
+  printStepHeader(5, totalSteps, 'Installing dependencies');
+
+  if (options.skipInstall) {
+    console.log(chalk.gray('  Skipped (--skip-install)'));
+    passedSteps++;
+  } else {
+    if (options.clean || !fs.existsSync(NODE_MODULES_PATH)) {
+      let doClean = options.clean;
+
+      if (!options.clean && fs.existsSync(NODE_MODULES_PATH)) {
+        doClean = await confirm({
+          message: 'Perform clean install (delete node_modules)?',
+          default: false,
+        });
+      }
+
+      if (doClean && fs.existsSync(NODE_MODULES_PATH)) {
+        console.log(chalk.gray('  Removing node_modules...'));
+        fs.rmSync(NODE_MODULES_PATH, { recursive: true, force: true });
+      }
+    }
+
+    console.log(chalk.gray('  Running npm install...'));
+    const installResult = await execCommandStreaming('npm', ['install'], options.verbose);
+
+    if (installResult.success) {
+      console.log(chalk.green('  ✓ Dependencies installed'));
+      passedSteps++;
+    } else {
+      console.log(chalk.red('  ✗ npm install failed'));
+      if (!options.verbose && installResult.output) {
+        console.log(chalk.gray(installResult.output.slice(0, 500)));
+      }
+      failedSteps++;
+    }
+  }
+
+  // Step 6: npm update
+  printStepHeader(6, totalSteps, 'Updating dependencies');
+
+  if (options.skipInstall) {
+    console.log(chalk.gray('  Skipped (--skip-install)'));
+    passedSteps++;
+  } else {
+    console.log(chalk.gray('  Running npm update...'));
+    const updateResult = await execCommandStreaming('npm', ['update'], options.verbose);
+
+    if (updateResult.success) {
+      console.log(chalk.green('  ✓ Dependencies updated'));
+      passedSteps++;
+    } else {
+      console.log(chalk.yellow('  ⚠ npm update had issues (non-critical)'));
+      warnings++;
+      passedSteps++;
+    }
+  }
+
+  // Step 7: MP type generation
+  printStepHeader(7, totalSteps, 'Generating Ministry Platform types');
+  console.log(chalk.gray('  Running mp:generate:models...'));
+
+  const generateResult = await execCommandStreaming(
+    'npm',
+    ['run', 'mp:generate:models'],
+    options.verbose
+  );
+
+  if (generateResult.success) {
+    const fileCount = countFilesInDir(MODELS_PATH);
+    console.log(chalk.green(`  ✓ ${fileCount} files generated`));
+    passedSteps++;
+  } else {
+    console.log(chalk.red('  ✗ Type generation failed'));
+    if (!options.verbose && generateResult.output) {
+      console.log(chalk.gray(generateResult.output.slice(0, 500)));
+    }
+    failedSteps++;
+  }
+
+  // Step 8: Build validation
+  printStepHeader(8, totalSteps, 'Building project');
+  console.log(chalk.gray('  Running npm run build...'));
+
+  const buildResult = await execCommandStreaming('npm', ['run', 'build'], options.verbose);
+
+  if (buildResult.success) {
+    console.log(chalk.green('  ✓ Build successful'));
+    passedSteps++;
+  } else {
+    console.log(chalk.red('  ✗ Build failed'));
+    if (!options.verbose && buildResult.output) {
+      // Show last part of output for build errors
+      const lines = buildResult.output.split('\n');
+      const lastLines = lines.slice(-20).join('\n');
+      console.log(chalk.gray(lastLines));
+    }
+    failedSteps++;
+  }
+
+  // Step 9: Summary
+  console.log(chalk.bold.blue('\n\nSetup Complete!'));
+  console.log(chalk.blue('==============='));
+
+  const totalChecks = passedSteps + failedSteps;
+  if (failedSteps === 0) {
+    console.log(chalk.green(`✓ ${passedSteps}/${totalChecks} steps passed`));
+    if (warnings > 0) {
+      console.log(chalk.yellow(`  (${warnings} warning${warnings > 1 ? 's' : ''})`));
+    }
+  } else {
+    console.log(
+      chalk.red(`✗ ${passedSteps}/${totalChecks} steps passed, ${failedSteps} failed`)
+    );
+  }
+
+  console.log(chalk.bold('\nNext steps:'));
+  console.log(chalk.white("  1. Run 'npm run dev' to start development server"));
+  console.log(chalk.white('  2. Visit http://localhost:3000'));
+
+  return failedSteps > 0 ? 1 : 0;
+}
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+async function main(): Promise<void> {
+  // Handle Ctrl+C gracefully
+  process.on('SIGINT', () => {
+    console.log(chalk.yellow('\n\nSetup cancelled by user.'));
+    process.exit(130);
+  });
+
+  const options = parseArguments();
+
+  let exitCode: number;
+
+  if (options.check) {
+    exitCode = runCheckMode();
+  } else {
+    exitCode = await runInteractiveSetup(options);
+  }
+
+  process.exit(exitCode);
+}
+
+main().catch((error) => {
+  console.error(chalk.red('Setup failed with an unexpected error:'));
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add interactive CLI setup command (`npm run setup`) that guides developers through complete project initialization
- Implement 9-step wizard: Node.js check, git status, env file creation, env var validation with prompts, npm install/update, MP type generation, and build validation
- Add `--check` flag for validation-only mode (`npm run setup:check`)
- Update README with "Quick Setup with Claude Code" section and document all Claude Code commands (`/audit-deps`, `/branch-commit`, `/pr`)

## Test plan

- [ ] Run `npm run setup:check` to verify validation mode works
- [ ] Run `npm run setup -- --help` to verify help output
- [ ] Clone fresh repo and run `npm run setup` to test full interactive flow
- [ ] Test `--clean` flag deletes node_modules before install
- [ ] Test `--skip-install` flag skips npm operations
- [ ] Verify NEXTAUTH_SECRET auto-generation works

🤖 Generated with [Claude Code](https://claude.ai/code)