### PR TITLE
Fix model generator crash for tables starting with digits

### DIFF
--- a/src/lib/providers/ministry-platform/scripts/generate-types.ts
+++ b/src/lib/providers/ministry-platform/scripts/generate-types.ts
@@ -139,11 +139,18 @@ function getTableName(table: TableMetadata): string | undefined {
 
 function sanitizeTypeName(name: string): string {
   // Convert table name to PascalCase and remove special characters
-  return name
+  let result = name
     .split(/[-_\s\/]+/) // Added slash to handle field names like "SSN/EIN"
     .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join("")
     .replace(/[^a-zA-Z0-9]/g, "");
+
+  // Prefix with underscore if the name starts with a digit (invalid TS identifier)
+  if (/^\d/.test(result)) {
+    result = `_${result}`;
+  }
+
+  return result;
 }
 
 function isValidIdentifier(name: string): boolean {


### PR DESCRIPTION
## Summary
- Fix `sanitizeTypeName()` to prefix an underscore when the generated type name starts with a digit, preventing invalid TypeScript identifiers
- Tables like `2026_Events` now produce `_2026Events` instead of the invalid `2026Events`
- No impact on existing tables — only affects table names that begin with digits

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Run `npm run mp:generate:models` against an MP instance with digit-prefixed tables and verify clean generation
- [ ] Verify existing generated types are unchanged

---

Generated with [Claude Code](https://claude.ai/code)