### PR TITLE
ci: add GitHub Actions test workflow with Codecov coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run tests with coverage
+        run: npx vitest run --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/coverage-final.json
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MPNext
 
+[![Tests](https://github.com/MinistryPlatform-Community/MPNext/actions/workflows/test.yml/badge.svg)](https://github.com/MinistryPlatform-Community/MPNext/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/MinistryPlatform-Community/MPNext/graph/badge.svg)](https://codecov.io/gh/MinistryPlatform-Community/MPNext)
+
 A modern Next.js application integrated with Ministry Platform authentication and REST API, built with TypeScript, Next.js 16, React 19, and Better Auth.
 
 ## Table of Contents


### PR DESCRIPTION
## Summary
- Add `.github/workflows/test.yml` — runs Vitest with v8 coverage on push to `main` and on pull requests
- Upload coverage results to Codecov via `codecov-action@v5`
- Add Tests status badge and Codecov coverage badge to `README.md`

## Setup Required
After merging, add the `CODECOV_TOKEN` repository secret:
1. Sign in at [codecov.io](https://codecov.io) with GitHub
2. Add the `MinistryPlatform-Community/MPNext` repo
3. Copy the upload token → **Settings → Secrets → Actions → `CODECOV_TOKEN`**

## Test plan
- [ ] Merge and verify the workflow runs on the merge commit
- [ ] Confirm Codecov receives the coverage upload (after adding token)
- [ ] Verify badges render in README on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)