### PR TITLE
ci: remove CODECOV_TOKEN (not required for public repos)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Remove `token` parameter from `codecov-action@v5` — not needed for public repositories

## Test plan
- [ ] Verify workflow passes and Codecov receives the upload without a token

🤖 Generated with [Claude Code](https://claude.ai/code)