### PR TITLE
ci: restore CODECOV_TOKEN for protected branch uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Re-add `token` parameter to `codecov-action@v5` — required for protected branches even on public repos

## Test plan
- [ ] Verify workflow passes and Codecov receives coverage upload

🤖 Generated with [Claude Code](https://claude.ai/code)