### PR TITLE
fix: replace NextAuth references with Better Auth

### DIFF
--- a/src/lib/providers/ministry-platform/docs/README.md
+++ b/src/lib/providers/ministry-platform/docs/README.md
@@ -27,9 +27,9 @@ ministry-platform/
 ├── provider.ts                 # Main provider class
 ├── helper.ts                   # Public API helper
 ├── auth/                       # Authentication
-│   ├── auth-provider.ts        # NextAuth provider
 │   ├── client-credentials.ts   # OAuth client credentials
-│   └── types.ts                # Auth-related types
+│   ├── types.ts                # Auth-related types
+│   └── index.ts                # Barrel export
 ├── services/                   # Service layer
 │   ├── table.service.ts
 │   ├── procedure.service.ts
@@ -87,7 +87,7 @@ MINISTRY_PLATFORM_CLIENT_SECRET=your_client_secret
 - ✅ Automatic OAuth2 token management
 - ✅ Service-oriented architecture
 - ✅ Zod schema validation
-- ✅ NextAuth integration
+- ✅ Better Auth integration
 - ✅ File upload/download support
 - ✅ Comprehensive error handling
 - ✅ Clean, standards-compliant code organization

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -5,6 +5,6 @@ import { vi } from 'vitest';
 vi.stubEnv('MINISTRY_PLATFORM_BASE_URL', 'https://test-mp.example.com');
 vi.stubEnv('OIDC_CLIENT_ID', 'test-client-id');
 vi.stubEnv('OIDC_CLIENT_SECRET', 'test-client-secret');
-vi.stubEnv('NEXTAUTH_SECRET', 'test-secret-key-for-testing');
-vi.stubEnv('NEXTAUTH_URL', 'http://localhost:3000');
+vi.stubEnv('BETTER_AUTH_SECRET', 'test-secret-key-for-testing');
+vi.stubEnv('BETTER_AUTH_URL', 'http://localhost:3000');
 vi.stubEnv('NODE_ENV', 'test');


### PR DESCRIPTION
## Summary
- **Setup script (`scripts/setup.ts`)**: Replace `NEXTAUTH_SECRET`/`NEXTAUTH_URL` env vars with `BETTER_AUTH_SECRET`/`BETTER_AUTH_URL`, remove unused optional vars (`OIDC_PROVIDER_NAME`, `OIDC_SCOPE`, `OIDC_WELL_KNOWN_URL`, `NEXTAUTH_DEBUG`), fix step count (10→9), and clean up derived URL logic
- **Test setup (`src/test-setup.ts`)**: Update env stubs from `NEXTAUTH_*` to `BETTER_AUTH_*` for consistency with the actual auth system
- **Documentation**: Update all stale NextAuth product references to Better Auth in `docs/OAUTH_LOGOUT_SETUP.md` and `src/lib/providers/ministry-platform/docs/README.md`, fix stale directory tree listing nonexistent `auth-provider.ts`

## Test plan
- [ ] Run `npm run setup -- --check` to verify the setup script validates correctly with new env var names
- [ ] Run `npm run test:run` to verify tests pass with updated env stubs
- [ ] Verify `.env.local` uses `BETTER_AUTH_SECRET`/`BETTER_AUTH_URL` (with `NEXTAUTH_*` fallbacks still supported in `src/lib/auth.ts`)

---

🤖 Generated with [Claude Code](https://claude.ai/code)