### PR TITLE
fix(security): sanitize filter parameters to prevent injection

### DIFF
--- a/src/lib/providers/ministry-platform/utils/filter-sanitize.test.ts
+++ b/src/lib/providers/ministry-platform/utils/filter-sanitize.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeFilterValue, sanitizeGuid } from './filter-sanitize';
+
+describe('sanitizeFilterValue', () => {
+  it('should return plain strings unchanged', () => {
+    expect(sanitizeFilterValue('John')).toBe('John');
+  });
+
+  it('should double single quotes for SQL escaping', () => {
+    expect(sanitizeFilterValue("O'Brien")).toBe("O''Brien");
+  });
+
+  it('should handle multiple single quotes', () => {
+    expect(sanitizeFilterValue("it's a 'test'")).toBe("it''s a ''test''");
+  });
+
+  it('should handle empty string', () => {
+    expect(sanitizeFilterValue('')).toBe('');
+  });
+
+  it('should not alter strings without quotes', () => {
+    expect(sanitizeFilterValue('Hello World 123')).toBe('Hello World 123');
+  });
+});
+
+describe('sanitizeGuid', () => {
+  it('should return a valid lowercase GUID unchanged', () => {
+    const guid = '12345678-1234-1234-1234-123456789abc';
+    expect(sanitizeGuid(guid)).toBe(guid);
+  });
+
+  it('should return a valid uppercase GUID unchanged', () => {
+    const guid = '12345678-1234-1234-1234-123456789ABC';
+    expect(sanitizeGuid(guid)).toBe(guid);
+  });
+
+  it('should accept mixed-case GUIDs', () => {
+    const guid = 'aB3d5678-Ef01-2345-6789-AbCdEf012345';
+    expect(sanitizeGuid(guid)).toBe(guid);
+  });
+
+  it('should throw on short strings', () => {
+    expect(() => sanitizeGuid('guid-123')).toThrow('Invalid GUID format');
+  });
+
+  it('should throw on empty string', () => {
+    expect(() => sanitizeGuid('')).toThrow('Invalid GUID format');
+  });
+
+  it('should throw on SQL injection attempt', () => {
+    expect(() => sanitizeGuid("'; DROP TABLE Contacts; --")).toThrow('Invalid GUID format');
+  });
+
+  it('should throw on GUID with wrong separator count', () => {
+    expect(() => sanitizeGuid('123456781234123412341234567890ab')).toThrow('Invalid GUID format');
+  });
+
+  it('should throw on GUID with invalid characters', () => {
+    expect(() => sanitizeGuid('1234567g-1234-1234-1234-123456789abc')).toThrow('Invalid GUID format');
+  });
+});

--- a/src/lib/providers/ministry-platform/utils/filter-sanitize.ts
+++ b/src/lib/providers/ministry-platform/utils/filter-sanitize.ts
@@ -1,0 +1,27 @@
+/**
+ * Filter sanitization utilities for Ministry Platform REST API queries.
+ *
+ * The MP API accepts an OData-style $filter parameter that maps to SQL WHERE clauses.
+ * All values interpolated into filter strings MUST be sanitized to prevent filter injection.
+ */
+
+/**
+ * Escapes a string value for safe interpolation inside a single-quoted filter value.
+ * Doubles single quotes (SQL standard escaping) so that input like O'Brien
+ * becomes O''Brien and cannot break out of the quoted context.
+ */
+export function sanitizeFilterValue(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Validates a GUID/UUID string format and returns the sanitized value.
+ * Throws if the value does not match the expected UUID v4 pattern.
+ */
+export function sanitizeGuid(guid: string): string {
+  const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!guidRegex.test(guid)) {
+    throw new Error('Invalid GUID format');
+  }
+  return guid;
+}

--- a/src/services/contactService.test.ts
+++ b/src/services/contactService.test.ts
@@ -69,19 +69,32 @@ describe('ContactService', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('should sanitize single quotes in search input', async () => {
+      mockGetTableRecords.mockResolvedValueOnce([]);
+
+      const service = await ContactService.getInstance();
+      await service.contactSearch("O'Brien");
+
+      const filter = mockGetTableRecords.mock.calls[0][0].filter;
+      expect(filter).toContain("O''Brien");
+      expect(filter).not.toContain("O'Brien");
+    });
   });
 
   describe('getContactByGuid', () => {
+    const validGuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
     it('should return contact when found', async () => {
-      const mockContact = { Contact_ID: 1, Contact_GUID: 'guid-123', First_Name: 'John' };
+      const mockContact = { Contact_ID: 1, Contact_GUID: validGuid, First_Name: 'John' };
       mockGetTableRecords.mockResolvedValueOnce([mockContact]);
 
       const service = await ContactService.getInstance();
-      const result = await service.getContactByGuid('guid-123');
+      const result = await service.getContactByGuid(validGuid);
 
       expect(mockGetTableRecords).toHaveBeenCalledWith({
         table: 'Contacts',
-        filter: "Contact_GUID = 'guid-123'",
+        filter: `Contact_GUID = '${validGuid}'`,
         select: expect.stringContaining('Contact_GUID'),
         top: 1,
       });
@@ -92,9 +105,14 @@ describe('ContactService', () => {
       mockGetTableRecords.mockResolvedValueOnce([]);
 
       const service = await ContactService.getInstance();
-      const result = await service.getContactByGuid('nonexistent-guid');
+      const result = await service.getContactByGuid(validGuid);
 
       expect(result).toBeNull();
+    });
+
+    it('should throw on invalid GUID format', async () => {
+      const service = await ContactService.getInstance();
+      await expect(service.getContactByGuid('not-a-guid')).rejects.toThrow('Invalid GUID format');
     });
   });
 

--- a/src/services/contactService.ts
+++ b/src/services/contactService.ts
@@ -1,5 +1,6 @@
 import { ContactSearch } from "@/lib/dto";
 import { MPHelper } from "@/lib/providers/ministry-platform";
+import { sanitizeFilterValue, sanitizeGuid } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 
 /**
  * ContactService - Singleton service for managing contact-related operations
@@ -54,7 +55,7 @@ export class ContactService {
   public async contactSearch(search: string): Promise<ContactSearch[]> {
     const records = await this.mp!.getTableRecords<ContactSearch>({
       table: "Contacts",
-      filter: `First_Name LIKE '%${search}%' OR Last_Name LIKE '%${search}%' OR Nickname LIKE '%${search}%' OR Email_Address LIKE '%${search}%' OR Mobile_Phone LIKE '%${search}%'`,
+      filter: `First_Name LIKE '%${sanitizeFilterValue(search)}%' OR Last_Name LIKE '%${sanitizeFilterValue(search)}%' OR Nickname LIKE '%${sanitizeFilterValue(search)}%' OR Email_Address LIKE '%${sanitizeFilterValue(search)}%' OR Mobile_Phone LIKE '%${sanitizeFilterValue(search)}%'`,
       select: "Contact_ID, Contact_GUID,First_Name,Nickname,Last_Name,Email_Address,Mobile_Phone,dp_fileUniqueId AS Image_GUID",
       top: 20
     });
@@ -71,7 +72,7 @@ export class ContactService {
   public async getContactByGuid(contactGuid: string): Promise<ContactSearch | null> {
     const records = await this.mp!.getTableRecords<ContactSearch>({
       table: "Contacts",
-      filter: `Contact_GUID = '${contactGuid}'`,
+      filter: `Contact_GUID = '${sanitizeGuid(contactGuid)}'`,
       select: "Contact_ID, Contact_GUID,First_Name,Nickname,Last_Name,Email_Address,Mobile_Phone,dp_fileUniqueId AS Image_GUID",
       top: 1
     });
@@ -92,8 +93,7 @@ export class ContactService {
     fields: Partial<Pick<ContactSearch, "Email_Address" | "Mobile_Phone">>
   ): Promise<void> {
     const record = { Contact_ID: contactId, ...fields };
-    console.log("ContactService.updateContact - Updating record:", JSON.stringify(record, null, 2));
-    
+
     await this.mp!.updateTableRecords(
       "Contacts",
       [record]


### PR DESCRIPTION
## Summary

- `contactSearch()` interpolates user input directly into MP filter strings (`LIKE '%${search}%'`), allowing filter injection via crafted search terms (e.g., a single quote breaks out of the string context)
- `getContactByGuid()` interpolates an unvalidated GUID string into a filter — any non-GUID input can inject arbitrary filter clauses
- `updateContact()` logs the full contact record (including PII) to stdout via `console.log`

This PR adds a `filter-sanitize.ts` utility with `sanitizeFilterValue()` and `sanitizeGuid()`, then applies them in `contactService.ts`.

## Changes

| File | Change |
|------|--------|
| `src/lib/providers/ministry-platform/utils/filter-sanitize.ts` | New — `sanitizeFilterValue()` and `sanitizeGuid()` |
| `src/services/contactService.ts` | Sanitize search input, validate GUID, remove PII logging |

## Test plan

- [ ] `contactSearch("O'Brien")` returns results instead of erroring (single-quote escaping)
- [ ] `getContactByGuid("not-a-guid")` throws instead of querying MP
- [ ] `updateContact()` no longer logs record contents to stdout

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>