### PR TITLE
fix(security): remove verbose logging that exposes PII and tokens

### DIFF
--- a/src/lib/providers/ministry-platform/client.ts
+++ b/src/lib/providers/ministry-platform/client.ts
@@ -35,23 +35,15 @@ export class MinistryPlatformClient {
      * @throws Error if token refresh fails
      */
     public async ensureValidToken(): Promise<void> {
-        console.log("Checking token validity...");
-        console.log("Expires at: ", this.expiresAt);
-        console.log("Current time: ", new Date());
-
         // Check if token is expired or about to expire
         if (this.expiresAt < new Date()) {
-            console.log("Token expired, refreshing...");
-            
             try {
                 // Get new access token using client credentials flow
                 const creds = await getClientCredentialsToken();
                 this.token = creds.access_token;
-                
+
                 // Set expiration time with safety buffer (TOKEN_LIFE before actual expiration)
                 this.expiresAt = new Date(Date.now() + TOKEN_LIFE);
-                
-                console.log("Token refreshed. Expires at: ", this.expiresAt);
             } catch (error) {
                 console.error("Failed to refresh token:", error);
                 throw error;

--- a/src/lib/providers/ministry-platform/services/procedure.service.ts
+++ b/src/lib/providers/ministry-platform/services/procedure.service.ts
@@ -33,13 +33,9 @@ export class ProcedureService {
         try {
             await this.client.ensureValidToken();
 
-            console.log('Executing procedure:', procedure);
-            console.log('Query Params:', params);
-
             const endpoint = `/procs/${encodeURIComponent(procedure)}`;
             const data = await this.client.getHttpClient().get<unknown[][]>(endpoint, params);
-            
-            console.log('Procedure results:', data);
+
             return data;
         } catch (error) {
             console.error(`Error executing procedure ${procedure}:`, error);
@@ -57,13 +53,9 @@ export class ProcedureService {
         try {
             await this.client.ensureValidToken();
 
-            console.log('Executing procedure with body:', procedure);
-            console.log('Parameters:', parameters);
-
             const endpoint = `/procs/${encodeURIComponent(procedure)}`;
             const data = await this.client.getHttpClient().post<unknown[][]>(endpoint, parameters);
-            
-            console.log('Procedure results:', data);
+
             return data;
         } catch (error) {
             console.error(`Error executing procedure ${procedure}:`, error);

--- a/src/lib/providers/ministry-platform/services/table.service.ts
+++ b/src/lib/providers/ministry-platform/services/table.service.ts
@@ -15,13 +15,9 @@ export class TableService {
             try {
                 await this.client.ensureValidToken();
 
-                console.log('Fetching records from table:', table);
-                console.log('Query Params:', params);
-
                 const endpoint = `/tables/${encodeURIComponent(table)}`;
                 const data = await this.client.getHttpClient().get<T[]>(endpoint, params as QueryParams);
-        
-                console.log('Fetched records:', data);
+
                 return data;
             } catch (error) {
                 console.error(`Error fetching records from table ${table}:`, error);


### PR DESCRIPTION
## Summary

- `client.ts` logs token expiry timestamps on every API call, and token refresh events
- `table.service.ts` logs every query's parameters AND full response data (contact names, emails, phones, GUIDs)
- `procedure.service.ts` logs all procedure parameters and full result sets

In production this generates hundreds of thousands of log lines per day containing PII. This PR removes the verbose `console.log` calls while preserving `console.error` for actual failures.

## Changes

| File | Change |
|------|--------|
| `src/lib/providers/ministry-platform/client.ts` | Remove token validity/expiry/refresh logging |
| `src/lib/providers/ministry-platform/services/table.service.ts` | Remove query param and full response logging |
| `src/lib/providers/ministry-platform/services/procedure.service.ts` | Remove procedure param and result logging |

## Test plan

- [ ] API calls still work (error logging preserved for failures)
- [ ] stdout no longer contains contact names, emails, or phone numbers

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>