### PR TITLE
fix(security): expand filter sanitization to remaining GUID sites + LIKE wildcards

### DIFF
--- a/src/components/contact-logs/actions.test.ts
+++ b/src/components/contact-logs/actions.test.ts
@@ -62,8 +62,10 @@ import {
   getContactLogById,
 } from './actions';
 
+const validUserGuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
 const mockAuthSession = {
-  user: { id: 'internal-id', userGuid: 'user-guid-123' },
+  user: { id: 'internal-id', userGuid: validUserGuid },
 };
 
 describe('contact-logs actions', () => {

--- a/src/components/contact-logs/actions.ts
+++ b/src/components/contact-logs/actions.ts
@@ -4,6 +4,7 @@ import { ContactLog } from "@/lib/providers/ministry-platform/models/ContactLog"
 import { ContactLogTypes } from "@/lib/providers/ministry-platform/models/ContactLogTypes";
 import { ContactLogInput } from "@/lib/providers/ministry-platform/models/ContactLogSchema";
 import { ContactLogService } from "@/services/contactLogService";
+import { sanitizeGuid } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 
@@ -50,7 +51,7 @@ export async function createContactLog(
 
     const users = await mp.getTableRecords<{ User_ID: number }>({
       table: "dp_Users",
-      filter: `User_GUID = '${userGuid}'`,
+      filter: `User_GUID = '${sanitizeGuid(userGuid)}'`,
       select: "User_ID",
       top: 1
     });
@@ -102,7 +103,7 @@ export async function updateContactLog(
 
     const users = await mp.getTableRecords<{ User_ID: number }>({
       table: "dp_Users",
-      filter: `User_GUID = '${userGuid}'`,
+      filter: `User_GUID = '${sanitizeGuid(userGuid)}'`,
       select: "User_ID",
       top: 1
     });

--- a/src/lib/providers/ministry-platform/utils/filter-sanitize.test.ts
+++ b/src/lib/providers/ministry-platform/utils/filter-sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeFilterValue, sanitizeGuid } from './filter-sanitize';
+import { sanitizeFilterValue, sanitizeLikeValue, sanitizeGuid } from './filter-sanitize';
 
 describe('sanitizeFilterValue', () => {
   it('should return plain strings unchanged', () => {
@@ -20,6 +20,36 @@ describe('sanitizeFilterValue', () => {
 
   it('should not alter strings without quotes', () => {
     expect(sanitizeFilterValue('Hello World 123')).toBe('Hello World 123');
+  });
+});
+
+describe('sanitizeLikeValue', () => {
+  it('should return plain strings unchanged', () => {
+    expect(sanitizeLikeValue('John')).toBe('John');
+  });
+
+  it('should escape single quotes', () => {
+    expect(sanitizeLikeValue("O'Brien")).toBe("O''Brien");
+  });
+
+  it('should escape percent wildcards', () => {
+    expect(sanitizeLikeValue('100%')).toBe('100\\%');
+  });
+
+  it('should escape underscore wildcards', () => {
+    expect(sanitizeLikeValue('a_b')).toBe('a\\_b');
+  });
+
+  it('should escape backslashes before other escapes', () => {
+    expect(sanitizeLikeValue('a\\b')).toBe('a\\\\b');
+  });
+
+  it('should escape all special characters together', () => {
+    expect(sanitizeLikeValue("100%_o'reilly\\")).toBe("100\\%\\_o''reilly\\\\");
+  });
+
+  it('should handle empty string', () => {
+    expect(sanitizeLikeValue('')).toBe('');
   });
 });
 

--- a/src/lib/providers/ministry-platform/utils/filter-sanitize.ts
+++ b/src/lib/providers/ministry-platform/utils/filter-sanitize.ts
@@ -9,14 +9,33 @@
  * Escapes a string value for safe interpolation inside a single-quoted filter value.
  * Doubles single quotes (SQL standard escaping) so that input like O'Brien
  * becomes O''Brien and cannot break out of the quoted context.
+ *
+ * Use for equality comparisons: `Column = '${sanitizeFilterValue(value)}'`.
+ * For LIKE patterns, use {@link sanitizeLikeValue} instead.
  */
 export function sanitizeFilterValue(value: string): string {
   return value.replace(/'/g, "''");
 }
 
 /**
+ * Escapes a string value for safe interpolation inside a LIKE pattern.
+ * Escapes the SQL LIKE wildcards (`%`, `_`) and the backslash escape character
+ * itself, then doubles single quotes for string-literal escaping. Callers MUST
+ * include `ESCAPE '\'` in the LIKE clause for the escapes to be honored, e.g.
+ * `Column LIKE '%${sanitizeLikeValue(value)}%' ESCAPE '\\'`.
+ */
+export function sanitizeLikeValue(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_")
+    .replace(/'/g, "''");
+}
+
+/**
  * Validates a GUID/UUID string format and returns the sanitized value.
- * Throws if the value does not match the expected UUID v4 pattern.
+ * Accepts any UUID variant (v1–v5) — Ministry Platform GUIDs are not guaranteed
+ * to be v4. Throws if the value does not match the canonical 8-4-4-4-12 hex format.
  */
 export function sanitizeGuid(guid: string): string {
   const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/src/services/contactService.test.ts
+++ b/src/services/contactService.test.ts
@@ -84,6 +84,7 @@ describe('ContactService', () => {
 
   describe('getContactByGuid', () => {
     const validGuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const validButUnknownGuid = 'b2c3d4e5-f678-9012-3456-7890abcdef12';
 
     it('should return contact when found', async () => {
       const mockContact = { Contact_ID: 1, Contact_GUID: validGuid, First_Name: 'John' };
@@ -105,7 +106,7 @@ describe('ContactService', () => {
       mockGetTableRecords.mockResolvedValueOnce([]);
 
       const service = await ContactService.getInstance();
-      const result = await service.getContactByGuid(validGuid);
+      const result = await service.getContactByGuid(validButUnknownGuid);
 
       expect(result).toBeNull();
     });

--- a/src/services/contactService.ts
+++ b/src/services/contactService.ts
@@ -1,6 +1,6 @@
 import { ContactSearch } from "@/lib/dto";
 import { MPHelper } from "@/lib/providers/ministry-platform";
-import { sanitizeFilterValue, sanitizeGuid } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
+import { sanitizeLikeValue, sanitizeGuid } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 
 /**
  * ContactService - Singleton service for managing contact-related operations
@@ -53,9 +53,13 @@ export class ContactService {
    * @returns Promise<ContactSearch[]> - Array of matching contacts (limited to 20 results)
    */
   public async contactSearch(search: string): Promise<ContactSearch[]> {
+    const term = sanitizeLikeValue(search);
+    const filter = ["First_Name", "Last_Name", "Nickname", "Email_Address", "Mobile_Phone"]
+      .map((col) => `${col} LIKE '%${term}%' ESCAPE '\\'`)
+      .join(" OR ");
     const records = await this.mp!.getTableRecords<ContactSearch>({
       table: "Contacts",
-      filter: `First_Name LIKE '%${sanitizeFilterValue(search)}%' OR Last_Name LIKE '%${sanitizeFilterValue(search)}%' OR Nickname LIKE '%${sanitizeFilterValue(search)}%' OR Email_Address LIKE '%${sanitizeFilterValue(search)}%' OR Mobile_Phone LIKE '%${sanitizeFilterValue(search)}%'`,
+      filter,
       select: "Contact_ID, Contact_GUID,First_Name,Nickname,Last_Name,Email_Address,Mobile_Phone,dp_fileUniqueId AS Image_GUID",
       top: 20
     });

--- a/src/services/userService.test.ts
+++ b/src/services/userService.test.ts
@@ -28,10 +28,13 @@ describe('UserService', () => {
   });
 
   describe('getUserProfile', () => {
+    const validGuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const otherValidGuid = 'b2c3d4e5-f678-9012-3456-7890abcdef12';
+
     it('should fetch user profile with roles and groups', async () => {
       const mockProfile = {
         User_ID: 1,
-        User_GUID: 'test-guid-123',
+        User_GUID: validGuid,
         Contact_ID: 100,
         First_Name: 'John',
         Nickname: 'Johnny',
@@ -46,12 +49,12 @@ describe('UserService', () => {
         .mockResolvedValueOnce([{ User_Group_Name: 'Staff' }]);
 
       const service = await UserService.getInstance();
-      const result = await service.getUserProfile('test-guid-123');
+      const result = await service.getUserProfile(validGuid);
 
       expect(mockGetTableRecords).toHaveBeenCalledTimes(3);
       expect(mockGetTableRecords).toHaveBeenCalledWith({
         table: 'dp_Users',
-        filter: "User_GUID = 'test-guid-123'",
+        filter: `User_GUID = '${validGuid}'`,
         select: expect.stringContaining('User_ID'),
         top: 1,
       });
@@ -76,7 +79,7 @@ describe('UserService', () => {
       mockGetTableRecords.mockResolvedValueOnce([]);
 
       const service = await UserService.getInstance();
-      const result = await service.getUserProfile('nonexistent-guid');
+      const result = await service.getUserProfile(validGuid);
 
       expect(result).toBeUndefined();
       expect(mockGetTableRecords).toHaveBeenCalledTimes(1);
@@ -85,7 +88,7 @@ describe('UserService', () => {
     it('should return empty arrays when user has no roles or groups', async () => {
       const mockProfile = {
         User_ID: 2,
-        User_GUID: 'test-guid-456',
+        User_GUID: otherValidGuid,
         Contact_ID: 200,
         First_Name: 'Jane',
         Nickname: 'Jane',
@@ -100,7 +103,7 @@ describe('UserService', () => {
         .mockResolvedValueOnce([]);
 
       const service = await UserService.getInstance();
-      const result = await service.getUserProfile('test-guid-456');
+      const result = await service.getUserProfile(otherValidGuid);
 
       expect(result).toEqual({
         ...mockProfile,
@@ -113,7 +116,12 @@ describe('UserService', () => {
       mockGetTableRecords.mockRejectedValueOnce(new Error('API error'));
 
       const service = await UserService.getInstance();
-      await expect(service.getUserProfile('test-guid')).rejects.toThrow('API error');
+      await expect(service.getUserProfile(validGuid)).rejects.toThrow('API error');
+    });
+
+    it('should throw on invalid GUID format', async () => {
+      const service = await UserService.getInstance();
+      await expect(service.getUserProfile('not-a-guid')).rejects.toThrow('Invalid GUID format');
     });
   });
 });

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,5 +1,6 @@
 import { MPUserProfile } from "@/lib/providers/ministry-platform/types";
 import { MPHelper } from "@/lib/providers/ministry-platform";
+import { sanitizeGuid } from "@/lib/providers/ministry-platform/utils/filter-sanitize";
 
 /**
  * UserService - Singleton service for managing user-related operations
@@ -60,7 +61,7 @@ export class UserService {
   public async getUserProfile(id: string): Promise<MPUserProfile | undefined> {
     const records = await this.mp!.getTableRecords<MPUserProfile>({
       table: "dp_Users",
-      filter: `User_GUID = '${id}'`,
+      filter: `User_GUID = '${sanitizeGuid(id)}'`,
       select: "User_ID, User_GUID, Contact_ID_TABLE.First_Name,Contact_ID_TABLE.Nickname,Contact_ID_TABLE.Last_Name,Contact_ID_TABLE.Email_Address,Contact_ID_TABLE.Mobile_Phone,Contact_ID_TABLE.dp_fileUniqueId AS Image_GUID",
       top: 1
     });


### PR DESCRIPTION
## Summary

Follow-ups to #57 covering the review notes that were not addressed in that PR:

- **Remaining GUID interpolation sites** now use `sanitizeGuid()` for consistency with `contactService.getContactByGuid()`:
  - `userService.getUserProfile()` (`src/services/userService.ts:64`)
  - `createContactLog` and `updateContactLog` actions (`src/components/contact-logs/actions.ts:54,107`)
- **LIKE wildcard escaping**: new `sanitizeLikeValue()` escapes `\`, `%`, `_`, and `'`. `contactSearch()` now uses it with an `ESCAPE '\'` clause so user input like `50%` matches a literal "50%" instead of acting as a wildcard.
- **Misleading doc comment** in `filter-sanitize.ts` corrected — the regex accepts any UUID variant, not specifically v4 (MP GUIDs aren't guaranteed v4).
- **Test fixtures** updated to valid-format GUIDs in `userService.test.ts` and `contact-logs/actions.test.ts` (required now that `sanitizeGuid` validates them), plus an invalid-GUID throws case for `getUserProfile()`.
- **Renamed** the not-found case fixture in `contactService.test.ts` to `validButUnknownGuid` for intent clarity.

## Not addressed (out of scope)

Numeric ID interpolations in `userService.ts:75,80` and `contactLogService.ts:76,99,116` are TypeScript `number`-typed and not injectable as strings.

## Test plan

- [x] `npm run test:run` — 240/240 pass
- [x] `npm run lint` — clean
- [ ] `contactSearch("100%")` returns rows containing literal "100%" instead of treating `%` as a wildcard
- [ ] `getUserProfile("not-a-guid")` throws "Invalid GUID format"