### PR TITLE
chore(deps): upgrade better-auth 1.6.23 -> 1.7.1

### DIFF
--- a/.claude/references/auth.md
+++ b/.claude/references/auth.md
@@ -69,12 +69,59 @@ The cast is needed because `customSessionClient` type inference doesn't include 
 
 | Setting | Value | Notes |
 |---------|-------|-------|
-| `providerId` | `"ministry-platform"` | Used in OAuth URLs and `signIn.oauth2()` |
+| `providerId` | `"ministry-platform"` | Used in OAuth URLs and `signIn.social({ provider })` |
 | `discoveryUrl` | `${MP_BASE_URL}/oauth/.well-known/openid-configuration` | OIDC auto-discovery |
+| `accountIssuer` | `${MP_BASE_URL}/oauth` | Pins the account-identity namespace (see 1.7 notes below) |
 | `scopes` | `openid`, `offline_access`, `dataplatform/scopes/all` | Full MP API access |
-| `pkce` | `false` | MP doesn't support PKCE |
-| `getUserInfo` | Custom callback | Fetches OIDC userinfo, returns `id: profile.sub` |
-| `mapProfileToUser` | Custom callback | Stores `profile.id` (sub) as `userGuid` |
+| `pkce` | `false` | Explicitly disabled — 1.7 defaults this to `true` (see 1.7 notes below) |
+| `getUserInfo` | Custom callback | Fetches OIDC userinfo, returns `sub: profile.sub` |
+| `mapProfileToUser` | Custom callback | Stores `profile.sub` as `userGuid` |
+
+### Better Auth 1.7 migration notes
+
+Better Auth 1.7 rewrote the generic OAuth plugin as a first-class social
+provider. What changed here, and why each line in `src/lib/auth.ts` looks the
+way it does:
+
+| Change | What we do |
+|--------|-----------|
+| `signIn.oauth2()` removed | `src/app/signin/page.tsx` calls `authClient.signIn.social({ provider: "ministry-platform" })` |
+| `genericOAuthClient()` dropped | Removed from `src/lib/auth-client.ts`; only `customSessionClient` remains |
+| **Callback path moved** | `/api/auth/oauth2/callback/ministry-platform` → **`/api/auth/callback/ministry-platform`**. This URL must be registered as a redirect URI on the MP OAuth client (`OIDC_CLIENT_ID`) for every environment. |
+| Account identity keyed on `(issuer, accountId)` | `accountIssuer` is set explicitly (see below) |
+| Account subject no longer falls back to `id` | `getUserInfo` returns `sub` (see below) |
+| `pkce` defaults to `true` | Kept explicitly `false`; MP discovery *does* advertise `S256`, so this is a candidate follow-up |
+| ID tokens verified against provider JWKS | Automatic — MP publishes `jwks_uri`; also enables `nonce` binding |
+
+> ⚠️ **`getUserInfo` must return `sub`, not `id`.** MP's discovery document
+> advertises `id_token_signing_alg_values_supported`, so Better Auth treats the
+> provider as OIDC and its default `accountSubject` resolver reads
+> **`profile.sub`** off the raw profile. Pre-1.7 the resolver fell back to
+> `profile.id`; that fallback is gone. Returning only `id` resolves the account
+> subject to `""` and breaks account identity for every user. `src/auth.test.ts`
+> guards this by calling the real configured `getUserInfo`.
+
+> ⚠️ **`accountIssuer` must stay set.** 1.7 refuses to initialize a discovery
+> provider whose issuer it cannot pin down — a failed discovery fetch **throws
+> out of `betterAuth()`** instead of degrading silently as it did in 1.6.
+> Declaring the issuer keeps the account namespace stable across a transient MP
+> outage and keeps `src/lib/auth.ts` importable without network access (tests,
+> CI). Discovery still supplies the endpoints and the JWKS used to verify ID
+> tokens.
+
+> ℹ️ **`nonce` binding is now on.** Because MP publishes a `jwks_uri`, Better
+> Auth sends a server-generated `nonce` and rejects a callback whose `id_token`
+> does not echo it (OIDC Core §3.1.3.7). If MP ever stops returning the `nonce`
+> claim, sign-in fails with an `id_token failed verification` error; the escape
+> hatch is `disableIdTokenNonceBinding: true`, which removes `id_token` replay
+> protection.
+
+> ℹ️ **RP-initiated logout is available but unused.** MP's discovery document
+> exposes `end_session_endpoint`, so 1.7 can build the provider logout URL
+> itself (including `id_token_hint`, which our hand-rolled URL omits).
+> `handleSignOut()` still constructs the URL manually and ignores the `url` that
+> `auth.api.signOut()` now returns — a possible simplification, deliberately
+> left out of the 1.7 migration.
 
 ### User Additional Fields
 
@@ -100,6 +147,7 @@ user: {
 > menu, `userId: null`). This regressed once during the 1.4→1.6 upgrade.
 > `src/auth.test.ts` guards it by running the real better-auth parse function
 > against the real field config. Do not "tighten" this back to `input: false`.
+> Still true as of better-auth 1.7.
 
 ### customSession Callback
 
@@ -122,12 +170,13 @@ customSession(async ({ user, session }) => ({
 
 ```typescript
 import { createAuthClient } from "better-auth/react";
-import { genericOAuthClient, customSessionClient } from "better-auth/client/plugins";
+import { customSessionClient } from "better-auth/client/plugins";
 import type { auth } from "./auth";
 
+// `genericOAuthClient()` was dropped in better-auth 1.7 — generic OAuth
+// providers are reached through the standard social sign-in API.
 export const authClient = createAuthClient({
   plugins: [
-    genericOAuthClient(),
     customSessionClient<typeof auth>(),
   ],
 });
@@ -139,23 +188,27 @@ export const authClient = createAuthClient({
 |--------|---------|
 | `authClient.useSession()` | React hook — returns `{ data: session, isPending }` |
 | `authClient.getSession()` | Async — returns `{ data: session }` |
-| `authClient.signIn.oauth2({ providerId, callbackURL })` | Initiates OAuth flow |
+| `authClient.signIn.social({ provider, callbackURL })` | Initiates OAuth flow (was `signIn.oauth2({ providerId })` before 1.7) |
 | `authClient.signOut()` | Clears local session (use `handleSignOut` for full OIDC logout) |
 
 ## OAuth Flow
 
 ```
 1. User visits app → proxy checks session cookie → no cookie → redirect to /signin
-2. /signin page → authClient.signIn.oauth2({ providerId: "ministry-platform" })
+2. /signin page → authClient.signIn.social({ provider: "ministry-platform" })
 3. Redirect to MP OAuth → user authenticates → redirect to callback
-4. Callback URL: /api/auth/oauth2/callback/ministry-platform
+4. Callback URL: /api/auth/callback/ministry-platform
+   (moved from /api/auth/oauth2/callback/... in better-auth 1.7 — must be
+   registered as a redirect URI on the MP OAuth client)
 5. Better Auth:
    a. Exchanges code for tokens
-   b. Calls getUserInfo(tokens) → fetches OIDC profile → returns { id: sub, ... }
-   c. Calls mapProfileToUser(profile) → returns { userGuid: profile.id }
-   d. Creates user record (id=generated, userGuid=sub, email, name)
-   e. Creates account record (accountId=sub, tokens)
-   f. Creates session → sets JWT cookie
+   b. Verifies the id_token against MP's JWKS and the expected nonce
+   c. Calls getUserInfo(tokens) → fetches OIDC profile → returns { sub, ... }
+   d. Calls mapProfileToUser(profile) → returns { userGuid: profile.sub }
+   e. Resolves the account subject from profile.sub (OIDC default)
+   f. Creates user record (id=generated, userGuid=sub, email, name)
+   g. Creates account record (issuer=MP issuer, accountId=sub, tokens)
+   h. Creates session → sets JWT cookie
 6. Redirect to callbackURL → app loads with session
 7. UserProvider calls getCurrentUserProfile(userGuid) → loads MP profile
 ```
@@ -281,7 +334,8 @@ function MyComponent() {
 
 The following URLs must be configured in the Ministry Platform OAuth client:
 
-- **OAuth2 Callback URL**: `{APP_URL}/api/auth/oauth2/callback/ministry-platform`
+- **OAuth2 Callback URL**: `{APP_URL}/api/auth/callback/ministry-platform`
+  (was `{APP_URL}/api/auth/oauth2/callback/ministry-platform` before better-auth 1.7)
 - **Post-Logout Redirect URI**: `{APP_URL}` (or `{APP_URL}/signin`)
 
 ## Better Auth Upgrade Checklist
@@ -293,25 +347,43 @@ the `better-auth` version, do this before merging:
 
 1. **Read the changelog** between the old and new version, focusing on:
    `genericOAuth`, `customSession`, `additionalFields`, cookie cache / session
-   serialization, and `mapProfileToUser`.
-2. **Run the auth tests**: `npm run test:run src/auth.test.ts` — the
-   `better-auth 1.6 guard` test verifies `userGuid` still survives provider-profile
-   parsing against the real library.
-3. **Manual smoke test (required — nothing else catches this):**
+   serialization, `mapProfileToUser`, and account identity (`accountSubject` /
+   `accountIssuer`).
+2. **Check whether the callback path moved.** It changed once already (1.7:
+   `/api/auth/oauth2/callback/:id` → `/api/auth/callback/:id`). A moved callback
+   needs the new redirect URI registered on the MP OAuth client in **every**
+   environment before deploy — nothing in CI catches this.
+3. **Run the auth tests**: `npm run test:run src/auth.test.ts`. Three tests are
+   real library guards, not simulations:
+   - `better-auth 1.6 guard` — `userGuid` still survives provider-profile parsing.
+   - `better-auth 1.7 guard` (getUserInfo) — the profile still carries `sub`, which
+     the OIDC `accountSubject` resolver reads.
+   - `better-auth 1.7 guard` (accountIssuer) — the issuer is still pinned, so a
+     discovery failure can't throw out of `betterAuth()` or re-key accounts.
+4. **Manual smoke test (required — nothing else catches this):**
    - `npm run dev`, sign in through Ministry Platform.
    - Open `/api/auth/get-session` and confirm the session `user` object contains
      **`userGuid`** (non-null) and **`userId`** (non-null).
    - Confirm the header avatar renders and the user menu opens.
+   - Sign out and confirm the MP end-session redirect completes.
    - Existing sessions predate the new user-record shape, so **sign out and log in
      fresh** — don't test against a stale session.
-4. If `userGuid` is missing, check `parseAdditionalUserInputFromProviderProfile`
+5. **If sign-in fails at the callback**, check the dev-server log for the
+   provider-level errors better-auth emits at init and callback time:
+   - `id_token failed verification against the discovery JWKS or expected nonce`
+     → MP isn't echoing the `nonce`, or JWKS/audience changed. Escape hatch:
+     `disableIdTokenNonceBinding: true` (costs `id_token` replay protection).
+   - `discovery returned no valid data` → MP discovery is unreachable; the pinned
+     `accountIssuer` keeps init from throwing, but sign-in still needs discovery
+     for the endpoints.
+6. If `userGuid` is missing, check `parseAdditionalUserInputFromProviderProfile`
    in `node_modules/better-auth/dist/db/schema.mjs` — the library may have changed
    how additional fields flow from the OAuth profile into the user record.
 
 ## Known Limitations
 
 1. **No database (top refactor priority)**: With no `database` in the config, Better Auth uses an in-memory adapter. Sessions live only in the in-memory store + cookies, so they are lost whenever the process restarts. On serverless/Vercel this is severe: **every cold start or new function instance has an empty session store**, so once the 1-hour JWT cookie cache expires, a request that lands on a fresh instance returns `null` and the user appears logged out (blank avatar / redirect to `/signin`) intermittently. This also makes auth bugs hard to reproduce. **Recommendation:** configure a persistent database adapter (e.g. a Vercel Marketplace Postgres/Neon, or SQLite for local dev) before relying on this in production.
-2. **mapProfileToUser type narrowness**: The genericOAuth TypeScript type for `mapProfileToUser` doesn't include `additionalFields`. The return must be cast to `Record<string, unknown>` for extra fields. The runtime code does pass them through correctly.
+2. ~~**mapProfileToUser type narrowness**~~ *(resolved in better-auth 1.7)*: `mapProfileToUser` now returns `OAuthMappedUser`, which permits arbitrary extra keys, so the old `as Record<string, unknown>` cast is gone. The type does forbid returning `id` — provider identity is owned by `accountSubject`.
 3. **userGuid type cast**: `session.user.userGuid` requires a type cast because `customSessionClient` doesn't infer `additionalFields` from `genericOAuth`. This is a Better Auth type limitation.
 4. **Token refresh**: Not explicitly implemented. The `storeAccountCookie` stores refresh tokens, but automatic refresh behavior in stateless mode is unverified.
 5. **Cookie cache staleness**: The 1-hour JWT cookie cache means `customSession` changes won't take effect until the cache expires or the user re-authenticates.

--- a/README.md
+++ b/README.md
@@ -188,15 +188,21 @@ Add these authorized redirect URIs where users will be sent after authentication
 
 **Development:**
 ```
-http://localhost:3000/api/auth/oauth2/callback/ministry-platform
+http://localhost:3000/api/auth/callback/ministry-platform
 ```
 
 **Production:**
 ```
-https://yourdomain.com/api/auth/oauth2/callback/ministry-platform
+https://yourdomain.com/api/auth/callback/ministry-platform
 ```
 
-> **Important**: The redirect URI must match exactly (including protocol, domain, port, and path). Ministry Platform will reject any OAuth requests with mismatched redirect URIs. The callback path uses Better Auth's genericOAuth plugin convention: `/api/auth/oauth2/callback/{providerId}`.
+> **Important**: The redirect URI must match exactly (including protocol, domain, port, and path). Ministry Platform will reject any OAuth requests with mismatched redirect URIs. The callback path follows Better Auth's social-provider convention: `/api/auth/callback/{providerId}`.
+
+> **Upgrading from a pre-1.7 Better Auth setup?** The callback path changed in
+> Better Auth 1.7, from `/api/auth/oauth2/callback/ministry-platform` to
+> `/api/auth/callback/ministry-platform`. Add the new URI to the Ministry
+> Platform OAuth client before deploying; keep the old one until every
+> environment is upgraded, then remove it.
 
 ##### Post-Logout Redirect URIs (Required)
 Add these URIs where users will be redirected after signing out:
@@ -298,7 +304,7 @@ npm run dev
 When deploying to production:
 
 1. Update `BETTER_AUTH_URL` to your production domain
-2. Add production redirect URI (`https://yourdomain.com/api/auth/oauth2/callback/ministry-platform`) to Ministry Platform OAuth client
+2. Add production redirect URI (`https://yourdomain.com/api/auth/callback/ministry-platform`) to Ministry Platform OAuth client
 3. Add production post-logout redirect URIs
 4. Ensure environment variables are set in your hosting provider
 5. Enable HTTPS/SSL certificates

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@types/js-cookie": "^3.0.6",
-        "better-auth": "^1.5.5",
+        "better-auth": "^1.7.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^17.3.1",
@@ -393,12 +393,12 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
-      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@opentelemetry/semantic-conventions": "^1.41.1",
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
       },
@@ -407,7 +407,7 @@
         "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.7",
+        "better-call": "1.4.0",
         "jose": "^6.1.0",
         "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
@@ -422,14 +422,14 @@
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
-      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.7.1.tgz",
+      "integrity": "sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
-        "drizzle-orm": "^0.45.2"
+        "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0"
       },
       "peerDependenciesMeta": {
         "drizzle-orm": {
@@ -438,12 +438,12 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
-      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.7.1.tgz",
+      "integrity": "sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "kysely": "^0.28.17 || ^0.29.0"
       },
@@ -454,22 +454,22 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
-      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.7.1.tgz",
+      "integrity": "sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
-      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.7.1.tgz",
+      "integrity": "sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
@@ -480,12 +480,12 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
-      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.7.1.tgz",
+      "integrity": "sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -500,12 +500,12 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
-      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.7.1.tgz",
+      "integrity": "sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.23",
+        "@better-auth/core": "^1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1"
       }
@@ -2599,9 +2599,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.42.0.tgz",
-      "integrity": "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -5642,27 +5642,27 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
-      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.7.1.tgz",
+      "integrity": "sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.6.23",
-        "@better-auth/drizzle-adapter": "1.6.23",
-        "@better-auth/kysely-adapter": "1.6.23",
-        "@better-auth/memory-adapter": "1.6.23",
-        "@better-auth/mongo-adapter": "1.6.23",
-        "@better-auth/prisma-adapter": "1.6.23",
-        "@better-auth/telemetry": "1.6.23",
+        "@better-auth/core": "1.7.1",
+        "@better-auth/drizzle-adapter": "1.7.1",
+        "@better-auth/kysely-adapter": "1.7.1",
+        "@better-auth/memory-adapter": "1.7.1",
+        "@better-auth/mongo-adapter": "1.7.1",
+        "@better-auth/prisma-adapter": "1.7.1",
+        "@better-auth/telemetry": "1.7.1",
         "@better-auth/utils": "0.4.2",
         "@better-fetch/fetch": "1.3.1",
-        "@noble/ciphers": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.7",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "better-call": "1.4.0",
         "defu": "^6.1.4",
-        "jose": "^6.1.3",
+        "jose": "^6.2.3",
         "kysely": "^0.28.17 || ^0.29.0",
-        "nanostores": "^1.1.1",
+        "nanostores": "^1.3.0",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
@@ -5672,8 +5672,8 @@
         "@tanstack/react-start": "^1.0.0",
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": "^0.45.2",
+        "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1",
+        "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -5747,15 +5747,15 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
-      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.4.0.tgz",
+      "integrity": "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.4.0",
-        "@better-fetch/fetch": "^1.1.21",
-        "rou3": "^0.7.12",
-        "set-cookie-parser": "^3.0.1"
+        "@better-auth/utils": "^0.5.0",
+        "@better-fetch/fetch": "^1.3.1",
+        "rou3": "^0.9.1",
+        "set-cookie-parser": "^3.1.2"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -5764,6 +5764,15 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/better-call/node_modules/@better-auth/utils": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.5.0.tgz",
+      "integrity": "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
       }
     },
     "node_modules/bidi-js": {
@@ -8165,9 +8174,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8328,9 +8337,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.3.tgz",
-      "integrity": "sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.5.tgz",
+      "integrity": "sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -8847,9 +8856,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.0.tgz",
-      "integrity": "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.5.2.tgz",
+      "integrity": "sha512-B0UbxzK1s0CN8Xht6r+7iT5+xV8PTaRERR1nATeplRv1Rw5YLWfVAid0hkqY3EceqpG4RjTk8GAwIxQY39Rnwg==",
       "funding": [
         {
           "type": "github",
@@ -9672,9 +9681,9 @@
       }
     },
     "node_modules/rou3": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
-      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.2.tgz",
+      "integrity": "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -9793,9 +9802,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
-      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@types/js-cookie": "^3.0.6",
-    "better-auth": "^1.5.5",
+    "better-auth": "^1.7.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^17.3.1",

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -22,8 +22,10 @@ function SignInContent() {
         // User is not signed in, initiate sign in
         console.log("Redirecting to SignIn API");
         setIsRedirecting(true);
-        authClient.signIn.oauth2({
-          providerId: "ministry-platform",
+        // better-auth 1.7 routes generic OAuth providers through the standard
+        // social sign-in path; `signIn.oauth2()` was removed.
+        authClient.signIn.social({
+          provider: "ministry-platform",
           callbackURL: callbackUrl,
         });
       }

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseAdditionalUserInputFromProviderProfile } from 'better-auth/db';
-import { userAdditionalFields } from '@/lib/auth';
+import type {
+  GenericOAuthConfig,
+  GenericOAuthOptions,
+} from 'better-auth/plugins';
+import type { OAuth2Tokens } from '@better-auth/core/oauth2';
+import { auth, userAdditionalFields } from '@/lib/auth';
 
 /**
  * Auth Tests
  *
  * Tests for the Better Auth configuration in src/lib/auth.ts.
  * - customSession: lightweight name splitting only (no API calls)
- * - getUserInfo: fetches OIDC profile and returns id=sub (used as accountId)
+ * - getUserInfo: fetches the OIDC profile and returns `sub` (better-auth 1.7
+ *   resolves the account subject from it for OIDC discovery providers)
  * - mapProfileToUser: stores the OAuth sub claim as userGuid (additionalField)
  * - User profile loading is handled client-side by UserProvider
  */
@@ -132,60 +138,131 @@ describe('Auth - Custom Session Enrichment Logic', () => {
 });
 
 describe('Auth - OAuth Configuration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Reach into the real configured provider rather than re-simulating it, so
+   * these tests break when `src/lib/auth.ts` drifts from the contract
+   * better-auth actually enforces.
+   */
+  function getMpProviderConfig(): GenericOAuthConfig {
+    const plugins =
+      (auth.options as { plugins?: Array<Record<string, unknown>> }).plugins ?? [];
+    const plugin = plugins.find((pl) => pl.id === 'generic-oauth') as
+      | { options?: GenericOAuthOptions }
+      | undefined;
+    const config = plugin?.options?.config?.find(
+      (c) => c.providerId === 'ministry-platform',
+    );
+    if (!config) throw new Error('ministry-platform generic OAuth config not found');
+    return config;
+  }
+
   it('should configure Ministry Platform as generic OAuth provider', () => {
-    const config = {
-      providerId: 'ministry-platform',
-      scopes: ['openid', 'offline_access', 'http://www.thinkministry.com/dataplatform/scopes/all'],
-      pkce: false,
-    };
+    const config = getMpProviderConfig();
 
     expect(config.providerId).toBe('ministry-platform');
     expect(config.scopes).toContain('openid');
     expect(config.scopes).toContain('offline_access');
+    expect(config.scopes).toContain(
+      'http://www.thinkministry.com/dataplatform/scopes/all',
+    );
+    // MP rejects PKCE today; better-auth 1.7 defaults it to true (OAuth 2.1),
+    // so this must stay explicitly false until MP is verified to accept S256.
     expect(config.pkce).toBe(false);
+    expect(config.authorizationUrlParams).toEqual({ realm: 'realm' });
   });
 
-  it('should map getUserInfo profile to user info with sub as id', () => {
-    // Simulate the getUserInfo callback — returns id=sub for the accountId
-    const profile = {
-      sub: 'ab12cd34-ef56-7890-abcd-ef1234567890',
-      given_name: 'John',
-      family_name: 'Doe',
+  /**
+   * Regression guard for the better-auth 1.7 account-identity change.
+   *
+   * 1.7 keys accounts on (issuer, accountId) and refuses to initialize a
+   * discovery provider whose issuer it cannot resolve — a failed discovery
+   * fetch throws straight out of `betterAuth()`. An explicit `accountIssuer`
+   * pins the namespace so a transient MP outage cannot silently re-key existing
+   * accounts, and keeps this module importable without network access.
+   */
+  it('pins the account issuer explicitly (better-auth 1.7 guard)', () => {
+    const config = getMpProviderConfig();
+
+    expect(config.accountIssuer).toBe(
+      `${process.env.MINISTRY_PLATFORM_BASE_URL}/oauth`,
+    );
+  });
+
+  /**
+   * Regression guard for the better-auth 1.7 generic-OAuth rewrite.
+   *
+   * MP's discovery document advertises `id_token_signing_alg_values_supported`,
+   * so better-auth treats this provider as OIDC and its default
+   * `accountSubject` resolver reads `profile.sub` off the raw profile returned
+   * by `getUserInfo`. Before 1.7 the resolver fell back to `profile.id`; that
+   * fallback is gone, so returning only `id` (the pre-1.7 shape) resolves the
+   * account subject to "" and breaks account identity for every user.
+   */
+  it('returns sub (not id) from getUserInfo (better-auth 1.7 guard)', async () => {
+    const config = getMpProviderConfig();
+    const guid = 'ab12cd34-ef56-7890-abcd-ef1234567890';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          sub: guid,
+          given_name: 'John',
+          family_name: 'Doe',
+          email: 'john@example.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const profile = await config.getUserInfo!({
+      accessToken: 'access-token',
+    } as OAuth2Tokens);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${process.env.MINISTRY_PLATFORM_BASE_URL}/oauth/connect/userinfo`,
+      { headers: { Authorization: 'Bearer access-token' } },
+    );
+    // This is the field better-auth resolves the account subject from.
+    expect(profile).toMatchObject({
+      sub: guid,
+      name: 'John Doe',
       email: 'john@example.com',
-    };
-
-    const userInfo = {
-      id: profile.sub,
-      email: profile.email,
-      name: `${profile.given_name} ${profile.family_name}`,
-      image: undefined,
       emailVerified: true,
-    };
-
-    expect(userInfo.id).toBe('ab12cd34-ef56-7890-abcd-ef1234567890');
-    expect(userInfo.name).toBe('John Doe');
-    expect(userInfo.email).toBe('john@example.com');
-    expect(userInfo.image).toBeUndefined();
-    expect(userInfo.emailVerified).toBe(true);
+    });
   });
 
-  it('should map profile to user with userGuid via mapProfileToUser', () => {
-    // Simulate the mapProfileToUser callback
-    // It receives the getUserInfo result and extracts the sub as userGuid
-    const getUserInfoResult = {
-      id: 'ab12cd34-ef56-7890-abcd-ef1234567890',
+  it('returns null from getUserInfo when the userinfo request fails', async () => {
+    const config = getMpProviderConfig();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      config.getUserInfo!({ accessToken: 'bad-token' } as OAuth2Tokens),
+    ).resolves.toBeNull();
+  });
+
+  it('should map profile to user with userGuid via mapProfileToUser', async () => {
+    const config = getMpProviderConfig();
+    const guid = 'ab12cd34-ef56-7890-abcd-ef1234567890';
+
+    // mapProfileToUser receives the raw profile returned by getUserInfo, and
+    // as of 1.7 may not return `id` — provider identity belongs to
+    // accountSubject, so userGuid is our own additional field.
+    const mapped = await config.mapProfileToUser!({
+      sub: guid,
       email: 'john@example.com',
       name: 'John Doe',
-      image: undefined,
       emailVerified: true,
-    };
+    });
 
-    // mapProfileToUser extracts profile.id (the sub) as userGuid
-    const mappedFields = {
-      userGuid: getUserInfoResult.id,
-    };
-
-    expect(mappedFields.userGuid).toBe('ab12cd34-ef56-7890-abcd-ef1234567890');
+    expect(mapped).toEqual({ userGuid: guid });
+    expect(mapped).not.toHaveProperty('id');
   });
 
   /**

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,10 +1,12 @@
 import { createAuthClient } from "better-auth/react";
-import { genericOAuthClient, customSessionClient } from "better-auth/client/plugins";
+import { customSessionClient } from "better-auth/client/plugins";
 import type { auth } from "./auth";
 
+// `genericOAuthClient()` was dropped in better-auth 1.7: generic OAuth
+// providers are registered as first-class social providers, so they are reached
+// through the standard `signIn.social({ provider })` client API.
 export const authClient = createAuthClient({
   plugins: [
-    genericOAuthClient(),
     customSessionClient<typeof auth>(),
   ],
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -79,6 +79,15 @@ const options = {
         {
           providerId: "ministry-platform",
           discoveryUrl: `${mpBaseUrl}/oauth/.well-known/openid-configuration`,
+          // better-auth 1.7 keys accounts on (issuer, accountId) and REFUSES to
+          // initialize a discovery provider whose issuer it cannot pin down —
+          // a failed discovery fetch throws out of `betterAuth()` rather than
+          // degrading silently as it did in 1.6. Declaring the issuer keeps
+          // the account namespace stable (and the module importable without
+          // network access, e.g. in tests/CI). MP's discovery document reports
+          // exactly this value; discovery still supplies the endpoints and the
+          // JWKS used to verify ID tokens.
+          accountIssuer: `${mpBaseUrl}/oauth`,
           clientId: process.env.OIDC_CLIENT_ID!,
           clientSecret: process.env.OIDC_CLIENT_SECRET!,
           scopes: [
@@ -86,6 +95,10 @@ const options = {
             "offline_access",
             "http://www.thinkministry.com/dataplatform/scopes/all",
           ],
+          // OAuth 2.1 makes PKCE the 1.7 default. MP's discovery document does
+          // advertise `code_challenge_methods_supported: ["plain", "S256"]`,
+          // so this can likely be flipped to `true` — but that is a separate,
+          // separately-testable change from the 1.7 migration itself.
           pkce: false,
           authorizationUrlParams: {
             realm: "realm",
@@ -111,8 +124,15 @@ const options = {
 
             const profile = await response.json();
 
+            // `sub` (not `id`) is what better-auth 1.7 reads for the account
+            // subject. MP's discovery document advertises
+            // `id_token_signing_alg_values_supported`, so the provider is
+            // treated as OIDC and the default `accountSubject` resolver reads
+            // `profile.sub` from this raw profile. Returning only `id` (the
+            // pre-1.7 shape) resolves the subject to "" and breaks account
+            // identity. `src/auth.test.ts` guards this.
             return {
-              id: profile.sub,
+              sub: profile.sub,
               email: profile.email,
               name: `${profile.given_name} ${profile.family_name}`,
               image: undefined,
@@ -122,12 +142,14 @@ const options = {
           // Map the OAuth sub claim (User_GUID) to our custom userGuid field.
           // Better Auth generates its own internal user.id, so we need a
           // separate field to store the MP User_GUID for API lookups.
-          // The cast is needed because genericOAuth's type doesn't include additionalFields,
-          // but the runtime code does pass extra fields through to createOAuthUser.
+          // As of 1.7 `mapProfileToUser` receives the raw profile returned by
+          // `getUserInfo` above and may not return `id` — provider identity is
+          // owned by `accountSubject`. The return type allows arbitrary extra
+          // keys, so no cast is needed.
           mapProfileToUser: (profile) => {
             return {
-              userGuid: profile.id,
-            } as Record<string, unknown>;
+              userGuid: String(profile.sub ?? ""),
+            };
           },
         },
       ],


### PR DESCRIPTION
## Summary

Upgrades `better-auth` from **1.6.23** to **1.7.1** (range `^1.5.5` → `^1.7.1`).

1.7 rewrote the generic OAuth plugin as a first-class social provider and scoped account identity by trusted issuer. Both changes land directly on our Ministry Platform OIDC integration.

MP's live discovery document grounds the analysis — it advertises `id_token_signing_alg_values_supported: ["RS256"]`, `jwks_uri`, `end_session_endpoint`, and `code_challenge_methods_supported: ["plain", "S256"]`.

## Changes

| File | Change |
|---|---|
| `src/app/signin/page.tsx` | `signIn.oauth2({ providerId })` → `signIn.social({ provider })` |
| `src/lib/auth-client.ts` | dropped `genericOAuthClient()` |
| `src/lib/auth.ts` | `getUserInfo` returns `sub` instead of `id` |
| `src/lib/auth.ts` | pinned `accountIssuer` to `${MP_BASE_URL}/oauth` |
| `src/lib/auth.ts` | `mapProfileToUser` cast removed |

Two of these were silent-breakage risks:

**`getUserInfo` must return `sub`.** Because MP advertises ID-token signing algs, better-auth classifies the provider as OIDC and resolves the account subject from `profile.sub`. The pre-1.7 fallback to `profile.id` is gone, so the old shape would have resolved every account subject to `""`. Type-checking does not catch this — `id` is still a legal optional field on the profile.

**`accountIssuer` must be pinned.** 1.7 throws out of `betterAuth()` when discovery fails and no issuer is configured, where 1.6 degraded quietly. This surfaced as an unhandled rejection when importing `src/lib/auth.ts` under Vitest, which has no network. Pinning the issuer fixes the test-env boot, keeps the account namespace stable across a transient MP outage, and leaves discovery authoritative for endpoints and JWKS.

## Tests

The OAuth-config tests were re-simulating the callbacks inside the test file, so they passed happily against the now-wrong contract. They now pull the real configured provider off `auth.options` and invoke the actual `getUserInfo` / `mapProfileToUser`, so they break when the config drifts from what better-auth enforces.

Added guards for the `sub` account subject and the pinned `accountIssuer`. Both were verified to fail against the pre-upgrade shape, not just to pass against the new one.

- `279 tests passed` (21 files)
- `npm run lint` clean
- `npx tsc --noEmit` clean
- `npm run build` clean

## ⚠️ Deploy prerequisite

The callback path moved:

```
/api/auth/oauth2/callback/ministry-platform   ->   /api/auth/callback/ministry-platform
```

The new redirect URI must be registered on the Ministry Platform OAuth client (`OIDC_CLIENT_ID`) for **every** environment before deploying. Keep the old entry until all environments are upgraded, then remove it. Nothing in CI catches a missing registration.

## ⚠️ Not verified

**Sign-in has not been exercised against a live MP instance.** Because MP publishes a `jwks_uri`, 1.7 now verifies the `id_token` against MP's JWKS *and* enforces `nonce` binding. MP is IdentityServer-based and should echo the `nonce`, but that could not be confirmed without a real login.

If it doesn't, sign-in fails with `id_token failed verification against the discovery JWKS or expected nonce`. Escape hatch is `disableIdTokenNonceBinding: true`, at the cost of `id_token` replay protection. Both are documented in the upgrade checklist.

Follow the manual smoke test in `.claude/references/auth.md` → *Better Auth Upgrade Checklist* before relying on this.

## Deliberately out of scope

- **PKCE.** MP discovery advertises S256, contradicting the `pkce: false` comment, so this can probably be enabled — but it's an independent variable and shouldn't confound the migration smoke test. Left explicit, commented, and asserted in tests.
- **`handleSignOut()` simplification.** 1.7 can build the MP end-session URL itself, including the `id_token_hint` our hand-rolled URL omits. `auth.api.signOut()` now returns that URL; our code ignores it, so nothing breaks. Noted as a follow-up rather than changing logout during an auth upgrade.

## Docs

`README.md` and `.claude/references/auth.md` updated for the new callback path, the client API, the OAuth flow, and an extended upgrade checklist. One stale "known limitation" (the `mapProfileToUser` cast) is now marked resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
